### PR TITLE
Shim process.env

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -245,7 +245,10 @@ var translateConfig = function(loader, packages){
 	}
 	if(!g.process) {
 		g.process = {
-			cwd: function(){}
+			cwd: function(){},
+			env: {
+				NODE_ENV: loader.env
+			}
 		};
 	}
 	

--- a/test/env.js
+++ b/test/env.js
@@ -1,0 +1,5 @@
+"format cjs";
+
+var env = process.env.NODE_ENV;
+
+module.exports = env;

--- a/test/test.js
+++ b/test/test.js
@@ -116,6 +116,17 @@ asyncTest("import self", function(){
 	}).then(start);
 });
 
+asyncTest("modules using process.env", function(){
+	GlobalSystem.env = "development";
+	GlobalSystem["delete"]("package.json!npm");
+	delete window.process;
+	GlobalSystem["import"]("package.json!npm").then(function() {
+		return GlobalSystem["import"]("test/env");
+	}).then(function(env){
+		equal(env, "development", "loaded the env");
+	}).then(start);
+});
+
 asyncTest("module names", function(){
 	makeIframe("not_relative_main/dev.html");
 });


### PR DESCRIPTION
This shims process.env and includes `NODE_ENV`, the most commonly used
variable in node.  Set to the value of `loader.env`. Fixes #28