### PR TITLE
Support browser string property

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -151,7 +151,7 @@ var utils = {
 			
 			// The refPkg might have a browser [https://github.com/substack/node-browserify#browser-field] mapping.
 			// Perform that mapping here.
-			if(refPkg.browser && (mapName in refPkg.browser)  && (!refPkg.system || !refPkg.system.ignoreBrowser)) {
+			if(refPkg.browser && (typeof refPkg.browser !== "string") && (mapName in refPkg.browser)  && (!refPkg.system || !refPkg.system.ignoreBrowser)) {
 				mappedName = refPkg.browser[mapName] === false ? "@empty" : refPkg.browser[mapName];
 			}
 			// globalBrowser looks like: {moduleName: aliasName, pgk: aliasingPkg}

--- a/test/browser/dev.html
+++ b/test/browser/dev.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main, "browser");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/browser/main-browser.js
+++ b/test/browser/main-browser.js
@@ -1,0 +1,1 @@
+module.exports = "browser";

--- a/test/browser/main.js
+++ b/test/browser/main.js
@@ -1,0 +1,1 @@
+module.exports = "node";

--- a/test/browser/package.json
+++ b/test/browser/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "browser-config",
+  "main": "main",
+  "version": "1.0.0",
+  "browser": "main-browser"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,10 @@ asyncTest("works when System.map and System.paths are provided", function(){
 	makeIframe("map_paths/dev.html");
 });
 
+asyncTest("browser config pointing to an alt main", function(){
+	makeIframe("browser/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
This adds support for the `browser` property in package.json when it is
a string to point to an alternative main for the browser. Fixes #21