### PR TITLE
Convert system.paths names

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -87,6 +87,9 @@ function convertSystem(context, pkg, system, root) {
 	if(system.map) {
 		system.map = convertPropertyNamesAndValues(context, pkg, system.map, root);
 	}
+	if(system.paths) {
+		system.paths = convertPropertyNames(context, pkg, system.paths, root);
+	}
 	// needed for builds
 	if(system.buildConfig) {
 		system.buildConfig = convertSystem(context, pkg, system.buildConfig, root);

--- a/test/map_paths/dev.html
+++ b/test/map_paths/dev.html
@@ -19,6 +19,10 @@
 		}
 
 		System.import("package.json!npm").then(function(){
+			if(hasQUnit()) {
+				QUnit.equal(System.paths["dep@1.2.2#other"], "other.js");
+			}
+
 			System.config({
 				map: {
 					"dep/dep": "dep"

--- a/test/map_paths/package.json
+++ b/test/map_paths/package.json
@@ -5,5 +5,8 @@
     "dep": "1.2.2"
   },
   "system": {
+    "paths": {
+      "dep/other": "other.js"
+    }
   }
 }


### PR DESCRIPTION
Same way we do for map and meta, this makes paths set in system.paths
get converted to an npm moduleName. Fixes #27