### PR TITLE
Support browser's falsey option

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -75,6 +75,9 @@ exports.addExtension = function(System){
 					utils.pkg.main(depPkg);
 				return oldNormalize.call(this, localName, parentName, parentAddress);
 			}
+			if(refPkg.browser && refPkg.browser[name]) {
+				return oldNormalize.call(this, refPkg.browser[name], parentName, parentAddress);
+			}
 			return oldNormalize.call(this, name, parentName, parentAddress);
 		}
 		

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -50,6 +50,9 @@ var utils = {
 			if(standard) {
 				return descriptor.moduleName;
 			} else {
+				if(descriptor === "@empty") {
+					return descriptor;
+				}
 				var modulePath;
 				if(descriptor.modulePath) {
 					modulePath = descriptor.modulePath.substr(0,2) === "./" ? descriptor.modulePath.substr(2) : descriptor.modulePath;
@@ -82,7 +85,7 @@ var utils = {
 			var versionParts = modulePathParts[0].split("@");
 			// it could be something like `@empty`
 			if(!modulePathParts[1] && !versionParts[0]) {
-				versionParts = ["@"+versionParts[0]];
+				versionParts = ["@"+versionParts[1]];
 			}
 			var packageName, 
 				modulePath;

--- a/test/browser-false/dev.html
+++ b/test/browser-false/dev.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main, "object");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/browser-false/main.js
+++ b/test/browser-false/main.js
@@ -1,0 +1,3 @@
+var dep = require("dep");
+
+module.exports = dep;

--- a/test/browser-false/node_modules/dep/main.js
+++ b/test/browser-false/node_modules/dep/main.js
@@ -1,0 +1,5 @@
+"format cjs";
+
+var foo = require("foo");
+
+module.exports = typeof foo;

--- a/test/browser-false/node_modules/dep/package.json
+++ b/test/browser-false/node_modules/dep/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep",
+	"main": "main",
+	"browser": {
+		"foo": false
+	}
+}

--- a/test/browser-false/package.json
+++ b/test/browser-false/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "browser-config-false",
+  "main": "main",
+  "version": "1.0.0",
+  "dependencies": {
+    "dep": "^4.3.0"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -163,6 +163,10 @@ asyncTest("browser config pointing to an alt main", function(){
 	makeIframe("browser/dev.html");
 });
 
+asyncTest("browser config to ignore a module", function(){
+	makeIframe("browser-false/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
`browser` can be used to ignore a module. There seemed to be partial
support for this functionality in the existing code but it didn't
actually work because normalize always wants to find a package, but
there won't be one for something like `@empty`. The fix is to make
`refPkg.browser` a sort of fall-through mapping for modules when a
package isn't found.

This fixes one of the issues raised in #26.