### PR TITLE
Cache warnings to prevent too many occurrences

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -160,7 +160,7 @@ function convertName (context, pkg, map, root, name) {
 				} else {
 					var requestedProject = crawl.getDependencyMap(context.loader, pkg, root)[parsed.packageName];
 					if(!requestedProject) {
-						console.warn("WARN: Could not find ", name , "in node_modules. Ignoring.");
+						warn(name);
 						return name;
 					}
 					requestedVersion = requestedProject.version;
@@ -310,3 +310,15 @@ var translateConfig = function(loader, packages){
 		loader.npmPaths[pkgAddress] = pkg;
 	});
 };
+
+var warn = (function(){
+	var warned = {};
+	return function(name){
+		if(!warned[name]) {
+			warned[name] = true;
+			var warning = "WARN: Could not find " + name + " in node_modules. Ignoring.";
+			if(console.warn) console.warn(warning);
+			else console.log(warning);
+		}
+	};
+})();


### PR DESCRIPTION
A warning for unknown dependencies is logged every time a moduleName is
created for converting the map, meta, and paths properties of system.
This leads to a large number of redundant warnings. The fix is to cache
the warnings so that they only occur once per moduleName. Fixes #39