### PR TITLE
Combine configDependencies with those already on loader

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -62,7 +62,7 @@ exports.translate = function(load){
 				packages[pkg.name+"@"+pkg.version] = true;
 			}
 		});
-		var configDependencies = ['@loader','npm-extension'].concat(packageDependencies(pkg));
+		var configDependencies = ['@loader','npm-extension'].concat(configDeps.call(loader, pkg));
 		var pkgMain = utils.pkg.hasDirectoriesLib(pkg) ?
 			convertName(context, pkg, false, true, pkg.name+"/"+utils.pkg.main(pkg)) :
 			utils.pkg.main(pkg);
@@ -231,11 +231,15 @@ function convertBrowserProperty(map, pkg, fromName, toName) {
 }
 
 // Dependencies from a package.json file specified in `system.configDependencies`
-function packageDependencies(pkg) {
+function configDeps(pkg) {
+	var deps = [];
 	if(pkg.system && pkg.system.configDependencies) {
-		return pkg.system.configDependencies;
+		deps = deps.concat(pkg.system.configDependencies);
 	}
-	return [];
+	if(this.configDependencies) {
+		deps = deps.concat(this.configDependencies);
+	}
+	return deps;
 }
 
 

--- a/test/config_deps/dev.html
+++ b/test/config_deps/dev.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		System.configDependencies = [ "global" ];
+	</script>
+	<script>
+		function hasQUnit() {
+			return typeof QUnit !== "undefined";
+		}
+
+		System["import"]("package.json!npm").then(function(){
+			if(hasQUnit()) {
+				QUnit.equal(window.DEP, "this is a config dep");
+			} else {
+				console.log(window.DEP);
+			}
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		}).then(function(){
+			window.removeMyself && removeMyself();
+		});
+	</script>
+</body>
+</html>

--- a/test/config_deps/global.js
+++ b/test/config_deps/global.js
@@ -1,0 +1,1 @@
+window.DEP = "this is a config dep";

--- a/test/config_deps/package.json
+++ b/test/config_deps/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "config-deps",
+  "main": "main",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -167,6 +167,10 @@ asyncTest("browser config to ignore a module", function(){
 	makeIframe("browser-false/dev.html");
 });
 
+asyncTest("configDependencies combined from loader and pkg.system", function(){
+	makeIframe("config_deps/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
In a build environment you might want to pass `configDependencies` as an
array that gets set on `System`. These should be combined with those
defined in `pkg.system.configDependencies` rather than be ignored. Fixes #44 