### PR TITLE
convertName with git versions now working

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -165,6 +165,11 @@ function convertName (context, pkg, map, root, name) {
 					}
 					requestedVersion = requestedProject.version;
 					depPkg = crawl.matchedVersion(context, parsed.packageName, requestedVersion);
+					// If we still didn't find one just use the first available version.
+					if(!depPkg) {
+						var versions = context.versions[parsed.packageName];
+						depPkg = versions && versions[requestedVersion];
+					}
 				}
 				// SYSTEM.NAME
 				if(depPkg.system && depPkg.system.name) {

--- a/test/git_config/another.js
+++ b/test/git_config/another.js
@@ -1,0 +1,3 @@
+module.exports = function(){
+	return "fake";
+};

--- a/test/git_config/dev.html
+++ b/test/git_config/dev.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				var result = main();
+
+				if(window.QUnit) {
+					QUnit.equal(result, "fake");
+					removeMyself();
+				} else {
+					console.log("result:", result);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/git_config/main.js
+++ b/test/git_config/main.js
@@ -1,0 +1,1 @@
+module.exports = require("dep");

--- a/test/git_config/node_modules/dep/main.js
+++ b/test/git_config/node_modules/dep/main.js
@@ -1,0 +1,3 @@
+module.exports = function(){
+	return "real";
+};

--- a/test/git_config/node_modules/dep/package.json
+++ b/test/git_config/node_modules/dep/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "dep",
+	"version": "0.0.1",
+	"main": "main"
+}

--- a/test/git_config/package.json
+++ b/test/git_config/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "mod",
+	"main": "main",
+	"dependencies": {
+		"dep": "git://github.com/fake/thing#master"
+	},
+	"system": {
+		"map": {
+			"dep": "./another"
+		}
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -171,6 +171,10 @@ asyncTest("configDependencies combined from loader and pkg.system", function(){
 	makeIframe("config_deps/dev.html");
 });
 
+asyncTest("Converting name of git versions works", function(){
+	makeIframe("git_config/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
This fixes #47. After doing semver comparison and not finding a match we
should just grab the version directly by name. This should always match
for exact name matches, as it does in the case of git urls.