### PR TITLE
Check for local mappings in normalize

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -65,7 +65,12 @@ exports.addExtension = function(System){
 			if(!parsedModuleName.modulePath) {
 				parsedModuleName.modulePath = utils.pkg.main(depPkg);
 			}
-			return oldNormalize.call(this, utils.moduleName.create(parsedModuleName), parentName, parentAddress);
+			var moduleName = utils.moduleName.create(parsedModuleName);
+			// Apply mappings, if they exist in the refPkg
+			if(refPkg.system && refPkg.system.map && refPkg.system.map[moduleName]) {
+				moduleName = refPkg.system.map[moduleName];
+			}
+			return oldNormalize.call(this, moduleName, parentName, parentAddress);
 		} else {
 			if(depPkg === this.npmPaths.__default) {
 				// if the current package, we can't? have the

--- a/test/map_same/can.js
+++ b/test/map_same/can.js
@@ -1,0 +1,3 @@
+module.exports = function(){
+	return "fake";
+};

--- a/test/map_same/dev.html
+++ b/test/map_same/dev.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main(), "fake");
+					removeMyself();
+				} else {
+					console.log(main());
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/map_same/main.js
+++ b/test/map_same/main.js
@@ -1,0 +1,1 @@
+module.exports = require("can");

--- a/test/map_same/node_modules/can/can.js
+++ b/test/map_same/node_modules/can/can.js
@@ -1,0 +1,3 @@
+module.exports = function(){
+	return "real";
+};

--- a/test/map_same/node_modules/can/package.json
+++ b/test/map_same/node_modules/can/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "can",
+	"main": "can",
+	"version": "1.0.0",
+	"system": {
+		"map": {
+			"can/can": "can"
+		}
+	}
+}

--- a/test/map_same/package.json
+++ b/test/map_same/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "mod",
+	"main": "main",
+	"dependencies": {
+		"can": "1.0.0"
+	},
+	"system": {
+		"map": {
+			"can": "./can"
+		}
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -175,6 +175,10 @@ asyncTest("Converting name of git versions works", function(){
 	makeIframe("git_config/dev.html");
 });
 
+asyncTest("local mappings are applied in normalize", function(){
+	makeIframe("map_same/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
Instead of always normalizing to a package name check for local mapping
for the referring package. This is because there could be another map
that is overriding, but the package-level map should take precedent.
Fixes #46