### PR TITLE
Adds an npmDependencies feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,24 @@ The following packages are ignored by default:
  - "bower"
  - "grunt", "grunt-cli"
 
+### npmDependencies
+
+Like `npmIgnore` but affirmative. If used alone will only include the dependencies listed. If used in conjunction with `npmIgnore` acts as an override. For example the following config:
+
+```js
+{
+  "dependencies": {
+    "one": "1.0.0",
+	"two": "1.0.0"
+  },
+  "system": {
+    "npmDependencies": [ "one" ]
+  }
+}
+```
+
+Will load `one` but ignore `two`.
+
 ### ignoreBrowser
 
 Set to true to ignore browserfy's `"browser"` and `"browserify"` configurations.

--- a/test/npm_deps_devignore/dev.html
+++ b/test/npm_deps_devignore/dev.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+
+		var fetch = System.fetch;
+		System.fetch = function(load){
+			if(/two/.test(load.name)) {
+				if(window.QUnit) {
+					QUnit.ok(false, "loading file we shouldn't load");
+				}
+			}
+			return fetch.call(this, load);
+		};
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main.name, "main", "got the main");
+					QUnit.equal(main.one.name, "one", "got one");
+					QUnit.equal(main.one.three.name, "three", "got three");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/npm_deps_devignore/main.js
+++ b/test/npm_deps_devignore/main.js
@@ -1,0 +1,6 @@
+var one = require("one");
+
+module.exports = {
+	name: "main",
+	one: one
+};

--- a/test/npm_deps_devignore/node_modules/one/main.js
+++ b/test/npm_deps_devignore/node_modules/one/main.js
@@ -1,0 +1,6 @@
+var three = require("three");
+
+module.exports = {
+	name: "one",
+	three: three
+};

--- a/test/npm_deps_devignore/node_modules/one/node_modules/three/main.js
+++ b/test/npm_deps_devignore/node_modules/one/node_modules/three/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: "three"
+};

--- a/test/npm_deps_devignore/node_modules/one/node_modules/three/package.json
+++ b/test/npm_deps_devignore/node_modules/one/node_modules/three/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "three",
+	"version": "1.0.0",
+	"main": "main"
+}

--- a/test/npm_deps_devignore/node_modules/one/package.json
+++ b/test/npm_deps_devignore/node_modules/one/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "one",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+		"three": "1.0.0"
+	}
+}

--- a/test/npm_deps_devignore/package.json
+++ b/test/npm_deps_devignore/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "my-module",
+	"version": "1.0.0",
+	"main": "main",
+	"devDependencies": {
+		"one": "1.0.0",
+		"two": "1.0.0"
+	},
+	"system": {
+		"npmIgnore": [
+			"devDependencies"
+		],
+		"npmDependencies": [
+			"one"
+		]
+	}
+}

--- a/test/npm_deps_ignore/dev.html
+++ b/test/npm_deps_ignore/dev.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+
+		var fetch = System.fetch;
+		System.fetch = function(load){
+			if(/two/.test(load.name)) {
+				if(window.QUnit) {
+					QUnit.ok(false, "loading file we shouldn't load");
+				}
+			}
+			return fetch.call(this, load);
+		};
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main.name, "main", "got the main");
+					QUnit.equal(main.one.name, "one", "got one");
+					QUnit.equal(main.one.three.name, "three", "got three");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/npm_deps_ignore/main.js
+++ b/test/npm_deps_ignore/main.js
@@ -1,0 +1,6 @@
+var one = require("one");
+
+module.exports = {
+	name: "main",
+	one: one
+};

--- a/test/npm_deps_ignore/node_modules/one/main.js
+++ b/test/npm_deps_ignore/node_modules/one/main.js
@@ -1,0 +1,6 @@
+var three = require("three");
+
+module.exports = {
+	name: "one",
+	three: three
+};

--- a/test/npm_deps_ignore/node_modules/one/node_modules/three/main.js
+++ b/test/npm_deps_ignore/node_modules/one/node_modules/three/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: "three"
+};

--- a/test/npm_deps_ignore/node_modules/one/node_modules/three/package.json
+++ b/test/npm_deps_ignore/node_modules/one/node_modules/three/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "three",
+	"version": "1.0.0",
+	"main": "main"
+}

--- a/test/npm_deps_ignore/node_modules/one/package.json
+++ b/test/npm_deps_ignore/node_modules/one/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "one",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+		"three": "1.0.0"
+	}
+}

--- a/test/npm_deps_ignore/package.json
+++ b/test/npm_deps_ignore/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "my-module",
+	"version": "1.0.0",
+	"main": "main",
+	"devDependencies": {
+		"one": "1.0.0",
+		"two": "1.0.0"
+	},
+	"system": {
+		"npmIgnore": [
+			"two"
+		]
+	}
+}

--- a/test/npm_deps_only/dev.html
+++ b/test/npm_deps_only/dev.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+
+		var fetch = System.fetch;
+		System.fetch = function(load){
+			if(/two/.test(load.name)) {
+				if(window.QUnit) {
+					QUnit.ok(false, "loading file we shouldn't load");
+				}
+			}
+			return fetch.call(this, load);
+		};
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main.name, "main", "got the main");
+					QUnit.equal(main.one.name, "one", "got one");
+					QUnit.equal(main.one.three.name, "three", "got three");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/npm_deps_only/main.js
+++ b/test/npm_deps_only/main.js
@@ -1,0 +1,6 @@
+var one = require("one");
+
+module.exports = {
+	name: "main",
+	one: one
+};

--- a/test/npm_deps_only/node_modules/one/main.js
+++ b/test/npm_deps_only/node_modules/one/main.js
@@ -1,0 +1,6 @@
+var three = require("three");
+
+module.exports = {
+	name: "one",
+	three: three
+};

--- a/test/npm_deps_only/node_modules/one/node_modules/three/main.js
+++ b/test/npm_deps_only/node_modules/one/node_modules/three/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: "three"
+};

--- a/test/npm_deps_only/node_modules/one/node_modules/three/package.json
+++ b/test/npm_deps_only/node_modules/one/node_modules/three/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "three",
+	"version": "1.0.0",
+	"main": "main"
+}

--- a/test/npm_deps_only/node_modules/one/package.json
+++ b/test/npm_deps_only/node_modules/one/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "one",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+		"three": "1.0.0"
+	}
+}

--- a/test/npm_deps_only/package.json
+++ b/test/npm_deps_only/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "my-module",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+		"one": "1.0.0",
+		"two": "1.0.0"
+	},
+	"system": {
+		"npmDependencies": [
+			"one"
+		]
+	}
+}

--- a/test/npm_deps_override/dev.html
+++ b/test/npm_deps_override/dev.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+
+		var fetch = System.fetch;
+		System.fetch = function(load){
+			if(/two/.test(load.name)) {
+				if(window.QUnit) {
+					QUnit.ok(false, "loading file we shouldn't load");
+				}
+			}
+			return fetch.call(this, load);
+		};
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main.name, "main", "got the main");
+					QUnit.equal(main.one.name, "one", "got one");
+					QUnit.equal(main.one.three.name, "three", "got three");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/npm_deps_override/main.js
+++ b/test/npm_deps_override/main.js
@@ -1,0 +1,6 @@
+var one = require("one");
+
+module.exports = {
+	name: "main",
+	one: one
+};

--- a/test/npm_deps_override/node_modules/one/main.js
+++ b/test/npm_deps_override/node_modules/one/main.js
@@ -1,0 +1,6 @@
+var three = require("three");
+
+module.exports = {
+	name: "one",
+	three: three
+};

--- a/test/npm_deps_override/node_modules/one/node_modules/three/main.js
+++ b/test/npm_deps_override/node_modules/one/node_modules/three/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: "three"
+};

--- a/test/npm_deps_override/node_modules/one/node_modules/three/package.json
+++ b/test/npm_deps_override/node_modules/one/node_modules/three/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "three",
+	"version": "1.0.0",
+	"main": "main"
+}

--- a/test/npm_deps_override/node_modules/one/package.json
+++ b/test/npm_deps_override/node_modules/one/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "one",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+		"three": "1.0.0"
+	}
+}

--- a/test/npm_deps_override/package.json
+++ b/test/npm_deps_override/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "my-module",
+	"version": "1.0.0",
+	"main": "main",
+	"devDependencies": {
+		"one": "1.0.0",
+		"two": "1.0.0"
+	},
+	"system": {
+		"npmIgnore": [
+			"devDependencies"
+		],
+		"npmDependencies": [
+			"one"
+		]
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -183,6 +183,24 @@ asyncTest("contextual maps work", function(){
 	makeIframe("contextual_map/dev.html");
 });
 
+QUnit.module("npmDependencies");
+
+asyncTest("are used exclusively if npmIgnore is not provided", function(){
+	makeIframe("npm_deps_only/dev.html");
+});
+
+asyncTest("override npmIgnore when npmIgnore is provided", function(){
+	makeIframe("npm_deps_override/dev.html");
+});
+
+asyncTest("ignores devDependencies when no npmDependencies is provided", function(){
+	makeIframe("npm_deps_devignore/dev.html");
+});
+
+asyncTest("npmIgnore a single module works", function(){
+	makeIframe("npm_deps_ignore/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
This adds an affirmative version of npmIgnore called `npmDependencies`.
Using this you can specify only the modules that you want to be
included.