### PR TITLE
configDependencies can export config with systemConfig

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -69,7 +69,8 @@ exports.translate = function(load){
 
 		return "define("+JSON.stringify(configDependencies)+", function(loader, npmExtension){\n" +
 			"npmExtension.addExtension(loader);\n"+
-		    (pkg.main ? "if(!loader.main){ loader.main = "+JSON.stringify(pkgMain)+"; }\n" : "") + 
+		    (pkg.main ? "if(!loader.main){ loader.main = "+JSON.stringify(pkgMain)+"; }\n" : "") +
+			"loader._npmExtensions = [].slice.call(arguments, 2);\n" +
 			"("+translateConfig.toString()+")(loader, "+JSON.stringify(packages, null, " ")+");\n" +
 		"});";
 	});
@@ -320,6 +321,12 @@ var translateConfig = function(loader, packages){
 		loader.npm[pkg.name+"@"+pkg.version] = pkg;
 		var pkgAddress = pkg.fileUrl.replace(/\/package\.json.*/,"");
 		loader.npmPaths[pkgAddress] = pkg;
+	});
+	forEach(loader._npmExtensions || [], function(ext){
+		// If there is a systemConfig use that as configuration
+		if(ext.systemConfig) {
+			loader.config(ext.systemConfig);
+		}
 	});
 };
 

--- a/test/ext_config/dev.html
+++ b/test/ext_config/dev.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main.one, "two", "mapping happened");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/ext_config/main.js
+++ b/test/ext_config/main.js
@@ -1,0 +1,5 @@
+var one = require("one");
+
+module.exports = {
+	one: one
+};

--- a/test/ext_config/node_modules/one/main.js
+++ b/test/ext_config/node_modules/one/main.js
@@ -1,0 +1,1 @@
+module.exports = "one";

--- a/test/ext_config/node_modules/one/package.json
+++ b/test/ext_config/node_modules/one/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "one",
+	"version": "1.0.0",
+	"main": "main.js"
+}

--- a/test/ext_config/override_deps.js
+++ b/test/ext_config/override_deps.js
@@ -1,0 +1,6 @@
+
+exports.systemConfig = {
+	map: {
+		one: "two"
+	}
+};

--- a/test/ext_config/package.json
+++ b/test/ext_config/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "extconfig",
+	"main": "main",
+	"dependencies": {
+		"one": "1.0.0"
+	},
+	"system": {
+		"configDependencies": [
+			"override_deps"
+		]
+	}
+}

--- a/test/ext_config/two.js
+++ b/test/ext_config/two.js
@@ -1,0 +1,1 @@
+module.exports = "two";

--- a/test/test.js
+++ b/test/test.js
@@ -183,6 +183,10 @@ asyncTest("contextual maps work", function(){
 	makeIframe("contextual_map/dev.html");
 });
 
+asyncTest("configDependencies can override config with systemConfig export", function(){
+	makeIframe("ext_config/dev.html");
+});
+
 QUnit.module("npmDependencies");
 
 asyncTest("are used exclusively if npmIgnore is not provided", function(){


### PR DESCRIPTION
This adds the ability for configDependencies to export configuration
using a special export called `systemConfig`. For example:

```js
exports.systemConfig = {
	map: {
		one: "two"
	}
};
```

This will run this object through `loader.config` after the extension
has been applied, so names are properly converted.

Not documenting for now as I think there are better solutions to this
problem long term.

Fixes #52