### PR TITLE
Fallback to /dir/index when /dir 404's

### DIFF
--- a/test/index_fallback/dev.html
+++ b/test/index_fallback/dev.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main, "index", "resolved to /index.js");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/index_fallback/main.js
+++ b/test/index_fallback/main.js
@@ -1,0 +1,1 @@
+module.exports = require('dep');

--- a/test/index_fallback/node_modules/dep/dir/index.js
+++ b/test/index_fallback/node_modules/dep/dir/index.js
@@ -1,0 +1,1 @@
+module.exports = 'index';

--- a/test/index_fallback/node_modules/dep/main.js
+++ b/test/index_fallback/node_modules/dep/main.js
@@ -1,0 +1,1 @@
+module.exports = require('./dir');

--- a/test/index_fallback/node_modules/dep/package.json
+++ b/test/index_fallback/node_modules/dep/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "dep",
+	"version": "1.0.0",
+	"main": "main.js"
+}

--- a/test/index_fallback/package.json
+++ b/test/index_fallback/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "extconfig",
+	"main": "main",
+	"dependencies": {
+		"dep": "1.0.0"
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -187,6 +187,10 @@ asyncTest("configDependencies can override config with systemConfig export", fun
 	makeIframe("ext_config/dev.html");
 });
 
+asyncTest("fallback to /dir/index on /dir 404", function(){
+	makeIframe("index_fallback/dev.html");
+});
+
 QUnit.module("npmDependencies");
 
 asyncTest("are used exclusively if npmIgnore is not provided", function(){


### PR DESCRIPTION
Support NodeJS's "Folders as Modules" syntax:

> If there is no `package.json` file present in the directory, then node will attempt to load an `index.js` or `index.node` file out of that directory. For example, if there was no `package.json` file in the above example, then `require('./some-library')` would attempt to load:
>
> - `./some-library/index.js`
