### PR TITLE
Make process a global like it is in a Node environment

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -62,12 +62,16 @@ exports.translate = function(load){
 				packages[pkg.name+"@"+pkg.version] = true;
 			}
 		});
-		var configDependencies = ['@loader','npm-extension'].concat(configDeps.call(loader, pkg));
+		var configDependencies = [
+			'@loader',
+			'npm-extension',
+			'process'
+		].concat(configDeps.call(loader, pkg));
 		var pkgMain = utils.pkg.hasDirectoriesLib(pkg) ?
 			convertName(context, pkg, false, true, pkg.name+"/"+utils.pkg.main(pkg)) :
 			utils.pkg.main(pkg);
 
-		return "define("+JSON.stringify(configDependencies)+", function(loader, npmExtension){\n" +
+		return "define("+JSON.stringify(configDependencies)+", function(loader, npmExtension, process){\n" +
 			"npmExtension.addExtension(loader);\n"+
 		    (pkg.main ? "if(!loader.main){ loader.main = "+JSON.stringify(pkgMain)+"; }\n" : "") +
 			"loader._npmExtensions = [].slice.call(arguments, 2);\n" +
@@ -255,12 +259,8 @@ function configDeps(pkg) {
 var translateConfig = function(loader, packages){
 	var g = loader.global;
 	if(!g.process) {
-		g.process = {
-			cwd: function(){},
-			env: {
-				NODE_ENV: loader.env
-			}
-		};
+		g.process = process;
+		g.process.env.NODE_ENV = loader.env;
 	}
 
 	if(!loader.npm) {

--- a/test/global_process/dev.html
+++ b/test/global_process/dev.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		System.env = 'fooEnv';
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(process){
+				if(window.QUnit) {
+					QUnit.ok(typeof process.cwd === 'function', "process.cwd() is defined");
+					QUnit.equal(process.browser, true, "browser flag is set");
+					QUnit.equal(process.env.NODE_ENV, 'fooEnv', "environment is set");
+					removeMyself();
+				} else {
+					console.log(process);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/global_process/main.js
+++ b/test/global_process/main.js
@@ -1,0 +1,1 @@
+module.exports = require('node-dep');

--- a/test/global_process/node_modules/node-dep/main.js
+++ b/test/global_process/node_modules/node-dep/main.js
@@ -1,0 +1,1 @@
+module.exports = process;

--- a/test/global_process/node_modules/node-dep/package.json
+++ b/test/global_process/node_modules/node-dep/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "node-dep",
+	"version": "1.0.0",
+	"main": "main.js"
+}

--- a/test/global_process/package.json
+++ b/test/global_process/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "browserify_shims",
+	"main": "main",
+	"dependencies": {
+		"node-dep": "1.0.0"
+	},
+	"system": {
+		"env": "chris"
+	}
+}

--- a/test/steal.html
+++ b/test/steal.html
@@ -15,7 +15,11 @@
 	<script src="../bower_components/qunit/qunit/qunit.js"></script>
 	<script>
 		steal = {
-			paths: {"npm": "npm.js", "npm-extension": "npm-extension.js"}
+			paths: {
+				"npm": "npm.js",
+				"npm-extension": "npm-extension.js",
+				"process": "node_modules/steal-builtins/node_modules/process/browser.js"
+			}
 		};
 	</script>
 	<script src="../node_modules/steal/steal.js" main="@empty"></script>

--- a/test/system_test_config.js
+++ b/test/system_test_config.js
@@ -6,3 +6,4 @@ System.paths["npm-crawl"] = "../../npm-crawl.js";
 System.paths["semver"] = "../../semver.js";
 System.paths["@traceur"] = "../../node_modules/steal/ext/traceur.js";
 System.paths["css"] = "../../node_modules/steal/ext/css.js";
+System.paths["process"] = "../../node_modules/steal-builtins/node_modules/process/browser";

--- a/test/test.js
+++ b/test/test.js
@@ -187,6 +187,10 @@ asyncTest("configDependencies can override config with systemConfig export", fun
 	makeIframe("ext_config/dev.html");
 });
 
+asyncTest("global process", function(){
+	makeIframe("global_process/dev.html");
+});
+
 QUnit.module("npmDependencies");
 
 asyncTest("are used exclusively if npmIgnore is not provided", function(){


### PR DESCRIPTION
Some npm packages use `process` since it's a global property in NodeJS: https://nodejs.org/api/globals.html#globals_global

Current this is addressed in two ways:

1. The `system-npm` package shims a few select properties for you by default: https://github.com/stealjs/system-npm/blob/master/npm.js#L258-L263
1. Adding `steal-builtins` as a dependency to your project gives you access to a `globalBrowser` `process` package that you can require, but still doesn't make `process` global: https://github.com/stealjs/node-browser-builtins/blob/master/package.json#L116

This PR is a sloppy proof of concept that uses the `steal-builtins#process` package to populate the default `process` property instead of the partial object that was being used before. 

