### PR TITLE
Only add the pkg name if not part of the main name.

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -63,9 +63,16 @@ exports.translate = function(load){
 			}
 		});
 		var configDependencies = ['@loader','npm-extension'].concat(configDeps.call(loader, pkg));
-		var pkgMain = utils.pkg.hasDirectoriesLib(pkg) ?
-			convertName(context, pkg, false, true, pkg.name+"/"+utils.pkg.main(pkg)) :
-			utils.pkg.main(pkg);
+		var pkgMain = utils.pkg.main(pkg);
+		// Convert the main if using directories.lib
+		if(utils.pkg.hasDirectoriesLib(pkg)) {
+			var mainHasPkg = pkgMain.indexOf(pkg.name) === 0;
+			if(mainHasPkg) {
+				pkgMain = convertName(context, pkg, false, true, pkgMain);
+			} else {
+				pkgMain = convertName(context, pkg, false, true, pkg.name+"/"+pkgMain);
+			}
+		}
 
 		return "define("+JSON.stringify(configDependencies)+", function(loader, npmExtension){\n" +
 			"npmExtension.addExtension(loader);\n"+


### PR DESCRIPTION
This accomodates two scenarios.  Previous we were accepting as a main:

```json
{
  "name": "foo",
  "main": "main"
}
```

Now this also allows for a main of:

```json
{
  "name": "foo",
  "main": "foo/main"
}
```

This is more *correct* when using directories.lib. Fixes #69