### PR TITLE
Adds support for npm3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@
 end_of_line = LF
 indent_style = tab
 indent_size = 4
+trim_trailing_whitespace = false

--- a/npm-extension.js
+++ b/npm-extension.js
@@ -107,7 +107,7 @@ exports.addExtension = function(System){
 			loader = this;
 		// @ is not the first character
 		if(parsedModuleName.version && this.npm && !loader.paths[load.name]) {
-			var pkg = this.npm[parsedModuleName.packageName];
+			var pkg = this.npm[utils.moduleName.nameAndVersion(parsedModuleName)];
 			if(pkg) {
 				return oldLocate.call(this, load).then(function(address){
 					var expectedAddress = utils.path.joinURIs(

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -186,6 +186,9 @@ var utils = {
 			} else {
 				return parsedModuleName;
 			}
+		},
+		nameAndVersion: function(parsedModuleName){
+			return parsedModuleName.packageName + "@" + parsedModuleName.version;
 		}
 	},
 	pkg: {
@@ -350,6 +353,11 @@ var utils = {
 		depPackage: function (parentPackageAddress, childName){
 			var packageFolderName = parentPackageAddress.replace(/\/package\.json.*/,"");
 			return (packageFolderName ? packageFolderName+"/" : "")+"node_modules/" + childName + "/package.json";
+		},
+		peerPackage: function(parentPackageAddress, childName){
+			var packageFolderName = parentPackageAddress.replace(/\/package\.json.*/,"");
+			return packageFolderName.substr(0, packageFolderName.lastIndexOf("/"))
+				+ "/" + childName + "/package.json";
 		},
 		// returns the package directory one level deeper.
 		depPackageDir: function(parentPackageAddress, childName){

--- a/npm.js
+++ b/npm.js
@@ -4,14 +4,10 @@
 var utils = require('./npm-utils');
 var crawl = require('./npm-crawl');
 
-
 // Add @loader, for SystemJS
 if(!System.has("@loader")) {
 	System.set('@loader', System.newModule({'default':System, __useDefault: true}));
 }
-
-
-
 
 // SYSTEMJS PLUGIN EXPORTS =================
 
@@ -38,8 +34,10 @@ exports.translate = function(load){
 		versions: {}
 	};
 	var pkg = {origFileUrl: load.address, fileUrl: load.address};
-
 	crawl.processPkgSource(context, pkg, load.source);
+	if(pkg.system && pkg.system.npmAlgorithm === "flat") {
+		context.isFlatFileStructure = true;
+	}
 
 	return crawl.deps(context, pkg, true).then(function(){
 		// clean up packages so everything is unique

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "steal-qunit": "bitovi/steal-qunit#master",
     "system-json": "0.0.2",
     "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
-    "testee": "^0.1.7",
+    "testee": "^0.2.2",
     "transpile": "bitovi/transpile#c2aeb23ad82b21fdf7f7da989bccbd6ad04e9f13"
   },
   "system": {

--- a/test/npm3/dev.html
+++ b/test/npm3/dev.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				// Tests are in the main.
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err);
+		});
+	</script>
+</body>
+</html>

--- a/test/npm3/main.js
+++ b/test/npm3/main.js
@@ -1,0 +1,12 @@
+var dep1 = require("dep1");
+var dep2 = require("dep2");
+
+if(window.QUnit) {
+	QUnit.equal(dep1.dep3, "1.0.0", "got version 1");
+	QUnit.equal(dep1.dep4, "1.0.0", "got version 1");
+	QUnit.equal(dep2.dep3, "1.0.0", "got version 1");
+	QUnit.equal(dep2.dep4, "2.0.0", "got version 2");
+	removeMyself();
+} else {
+	console.log("dep1",dep1,"dep2",dep2);
+}

--- a/test/npm3/node_modules/dep1/main.js
+++ b/test/npm3/node_modules/dep1/main.js
@@ -1,0 +1,2 @@
+exports["dep3"] = require("dep3");
+exports["dep4"] = require("dep4");

--- a/test/npm3/node_modules/dep1/package.json
+++ b/test/npm3/node_modules/dep1/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "dep1",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+		"dep3": "1.0.0",
+		"dep4": "1.0.0"
+	}
+}

--- a/test/npm3/node_modules/dep2/main.js
+++ b/test/npm3/node_modules/dep2/main.js
@@ -1,0 +1,2 @@
+exports["dep3"] = require("dep3");
+exports["dep4"] = require("dep4");

--- a/test/npm3/node_modules/dep2/node_modules/dep4/main.js
+++ b/test/npm3/node_modules/dep2/node_modules/dep4/main.js
@@ -1,0 +1,1 @@
+module.exports = "2.0.0";

--- a/test/npm3/node_modules/dep2/node_modules/dep4/package.json
+++ b/test/npm3/node_modules/dep2/node_modules/dep4/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep4",
+	"version": "2.0.0",
+	"main": "main",
+	"dependencies": {
+	}
+}

--- a/test/npm3/node_modules/dep2/package.json
+++ b/test/npm3/node_modules/dep2/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "dep2",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+		"dep3": "1.0.0",
+		"dep4": "2.0.0"
+	}
+}

--- a/test/npm3/node_modules/dep3/main.js
+++ b/test/npm3/node_modules/dep3/main.js
@@ -1,0 +1,1 @@
+module.exports = "1.0.0";

--- a/test/npm3/node_modules/dep3/package.json
+++ b/test/npm3/node_modules/dep3/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep3",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+	}
+}

--- a/test/npm3/node_modules/dep4/main.js
+++ b/test/npm3/node_modules/dep4/main.js
@@ -1,0 +1,1 @@
+module.exports = "1.0.0";

--- a/test/npm3/node_modules/dep4/package.json
+++ b/test/npm3/node_modules/dep4/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep4",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+	}
+}

--- a/test/npm3/package.json
+++ b/test/npm3/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "npmapp",
+	"version": "3.0.0",
+	"main": "main.js",
+	"dependencies": {
+		"dep1": "1.0.0",
+		"dep2": "1.0.0"
+	},
+	"system": {
+		"npmAlgorithm": "flat"
+	}
+}

--- a/test/steal.html
+++ b/test/steal.html
@@ -15,7 +15,12 @@
 	<script src="../bower_components/qunit/qunit/qunit.js"></script>
 	<script>
 		steal = {
-			paths: {"npm": "npm.js", "npm-extension": "npm-extension.js"}
+			paths: {
+				"npm": "npm.js",
+				"npm-extension": "npm-extension.js",
+				"npm-crawl": "npm-crawl.js",
+				"npm-utils": "npm-utils.js"
+			}
 		};
 	</script>
 	<script src="../node_modules/steal/steal.js" main="@empty"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -213,6 +213,10 @@ asyncTest("scoped packages work", function(){
 	makeIframe("scoped/dev.html");
 });
 
+asyncTest("works with npm 3's flat file structure", function(){
+	makeIframe("npm3/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
This adds support for npm3, closing #72

This adds an option `npmAlgorithm` that is used to turn on npm3 mode.
You can set it with:

```json
{
  "system": {
    "npmAlgorithm": "flat"
  }
}
```

Eventually we will make npm3 the default in a breaking change, but will
be opt-in for now until bugs are ironed out.