### PR TITLE
npm3: walk up the parents

### DIFF
--- a/test/npm3/main.js
+++ b/test/npm3/main.js
@@ -4,8 +4,10 @@ var dep2 = require("dep2");
 if(window.QUnit) {
 	QUnit.equal(dep1.dep3, "1.0.0", "got version 1");
 	QUnit.equal(dep1.dep4, "1.0.0", "got version 1");
+	QUnit.equal(dep1.dep5, "1.0.0", "got version 1");
 	QUnit.equal(dep2.dep3, "1.0.0", "got version 1");
-	QUnit.equal(dep2.dep4, "2.0.0", "got version 2");
+	QUnit.equal(dep2.dep4.version, "2.0.0", "got version 2");
+	QUnit.equal(dep2.dep4.dep5, "2.0.0", "got version 2");
 	removeMyself();
 } else {
 	console.log("dep1",dep1,"dep2",dep2);

--- a/test/npm3/node_modules/dep1/main.js
+++ b/test/npm3/node_modules/dep1/main.js
@@ -1,2 +1,3 @@
 exports["dep3"] = require("dep3");
 exports["dep4"] = require("dep4");
+exports["dep5"] = require("dep5");

--- a/test/npm3/node_modules/dep1/package.json
+++ b/test/npm3/node_modules/dep1/package.json
@@ -4,6 +4,7 @@
 	"main": "main",
 	"dependencies": {
 		"dep3": "1.0.0",
-		"dep4": "1.0.0"
+		"dep4": "1.0.0",
+		"dep5": "1.0.0"
 	}
 }

--- a/test/npm3/node_modules/dep2/node_modules/dep4/main.js
+++ b/test/npm3/node_modules/dep2/node_modules/dep4/main.js
@@ -1,1 +1,4 @@
-module.exports = "2.0.0";
+module.exports = {
+	version: "2.0.0",
+	"dep5": require("dep5")
+};

--- a/test/npm3/node_modules/dep2/node_modules/dep5/main.js
+++ b/test/npm3/node_modules/dep2/node_modules/dep5/main.js
@@ -1,0 +1,1 @@
+module.exports = "2.0.0";

--- a/test/npm3/node_modules/dep2/node_modules/dep5/package.json
+++ b/test/npm3/node_modules/dep2/node_modules/dep5/package.json
@@ -1,8 +1,7 @@
 {
-	"name": "dep4",
+	"name": "dep5",
 	"version": "2.0.0",
 	"main": "main",
 	"dependencies": {
-		"dep5": "2.0.0"
 	}
 }

--- a/test/npm3/node_modules/dep5/main.js
+++ b/test/npm3/node_modules/dep5/main.js
@@ -1,0 +1,1 @@
+module.exports = "1.0.0";

--- a/test/npm3/node_modules/dep5/package.json
+++ b/test/npm3/node_modules/dep5/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep5",
+	"version": "1.0.0",
+	"main": "main",
+	"dependencies": {
+	}
+}


### PR DESCRIPTION
This updates the NPM algorithm which should now be correct. The pattern
is:

1. Get the npm2 expected address.
2. Walk up the parent node_modules and look for a package with the same
name.
3. See if the package is semver compatible.
4. If it is compatible use that as the address (and will use the package
		itself).
5. If it is not compatible use the previous address (which is one down
		from the conflicting package).
6. Keep looping until you get all the way to the top and use that as the
address.

Fixes #86