### PR TITLE
Fix npm traversal after missing

### DIFF
--- a/test/nested_back/dev.html
+++ b/test/nested_back/dev.html
@@ -17,13 +17,7 @@
 		
 		System.import("package.json!npm").then(function(){
 			System.import(System.main).then(function(main){
-				if(window.QUnit) {
-					QUnit.equal(main, "object");
-					removeMyself();
-				} else {
-					console.log(main);
-				}
-				
+				// Tests are in the main.
 			}, function(e){
 				if(window.QUnit) {
 					QUnit.ok(false, e);
@@ -39,7 +33,7 @@
 			
 			
 		}).then(null, function(err){
-			console.error("Oh no, error!", err, err.stack);
+			console.error("Oh no, error!", err);
 		});
 	</script>
 </body>

--- a/test/nested_back/main.js
+++ b/test/nested_back/main.js
@@ -1,0 +1,12 @@
+var dep1 = require("dep1");
+
+if(window.QUnit) {
+	var dep2 = dep1.dep2;
+
+	QUnit.equal(dep1.version, "1.0.0", "got dep1");
+	QUnit.equal(dep2.version, "1.0.0", "got dep2");
+	QUnit.equal(dep2.dep3, "1.0.0", "got dep3");
+	removeMyself();
+} else {
+	console.log("dep1",dep1);
+}

--- a/test/nested_back/node_modules/dep1/main.js
+++ b/test/nested_back/node_modules/dep1/main.js
@@ -1,0 +1,4 @@
+module.exports = {
+	version: "1.0.0",
+	"dep2": require("dep2")
+};

--- a/test/nested_back/node_modules/dep1/node_modules/dep2/main.js
+++ b/test/nested_back/node_modules/dep1/node_modules/dep2/main.js
@@ -1,0 +1,4 @@
+module.exports = {
+	version: "1.0.0",
+	"dep3": require("dep3")
+};

--- a/test/nested_back/node_modules/dep1/node_modules/dep2/package.json
+++ b/test/nested_back/node_modules/dep1/node_modules/dep2/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep2",
+	"main": "main.js",
+	"dependencies": {
+		"dep3": "1.0.0"
+	}
+}

--- a/test/nested_back/node_modules/dep1/node_modules/dep3/main.js
+++ b/test/nested_back/node_modules/dep1/node_modules/dep3/main.js
@@ -1,0 +1,1 @@
+module.exports = "1.0.0";

--- a/test/nested_back/node_modules/dep1/node_modules/dep3/package.json
+++ b/test/nested_back/node_modules/dep1/node_modules/dep3/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep3",
+	"main": "main.js",
+	"dependencies": {
+		"dep2": "1.0.0"
+	}
+}

--- a/test/nested_back/node_modules/dep1/package.json
+++ b/test/nested_back/node_modules/dep1/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "dep1",
+	"main": "main.js",
+	"dependencies": {
+		"dep2": "1.0.0"
+	}
+}

--- a/test/nested_back/node_modules/dep2/package.json
+++ b/test/nested_back/node_modules/dep2/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "dep2",
+	"version": "0.0.5",
+	"main": "main.js"
+}

--- a/test/nested_back/package.json
+++ b/test/nested_back/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "nested_back",
+	"main": "main.js",
+	"version": "1.0.0",
+	"dependencies": {
+		"dep1": "1.0.0",
+		"dep2": "0.0.5"
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -221,6 +221,10 @@ asyncTest("works with child packages with version ranges", function(){
 	makeIframe("parent/dev.html");
 });
 
+asyncTest("With npm3 traversal starts by going to the mosted nested position", function(){
+	makeIframe("nested_back/dev.html");
+});
+
 // Only run these tests for StealJS (because it requires steal syntax)
 if(window.steal) {
 	asyncTest("canjs", function(){


### PR DESCRIPTION
When npm3 misses (looks for a package.json and doesn't find it) the
traversal is slightly different from npm2. In npm2 you would traverse UP
always. But with npm3 you are most likely starting from a less nested
position. So to traverse you start from the most nested position and
*then* traverse up.