### PR TITLE
Leave pkgs in context untouched

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "homepage": "https://github.com/stealjs/system-npm",
   "devDependencies": {
     "bower": "^1.3.12",
-    "can": "2.2.4",
+    "can": "2.3.9",
     "grunt": "^0.4.5",
     "grunt-contrib-copy": "^0.8.0",
-    "jquery": "^2.1.3",
+    "jquery": "2.1.3",
     "jquery-ui": "^1.10.5",
     "live-reload-testing": "^3.0.1",
     "lodash": "~2.4.1",

--- a/test/npm3/node_modules/component-emitter/package.json
+++ b/test/npm3/node_modules/component-emitter/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "component-emitter",
+	"main": "main",
+	"version": "1.1.2"
+}

--- a/test/npm3/node_modules/dep1/node_modules/component-emitter/package.json
+++ b/test/npm3/node_modules/dep1/node_modules/component-emitter/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "component-emitter",
+	"main": "main",
+	"version": "1.2.0"
+}

--- a/test/npm3/node_modules/dep1/package.json
+++ b/test/npm3/node_modules/dep1/package.json
@@ -5,6 +5,8 @@
 	"dependencies": {
 		"dep3": "1.0.0",
 		"dep4": "1.0.0",
-		"dep5": "1.0.0"
-	}
+		"dep5": "1.0.0",
+		"component-emitter": "1.2.0"
+	},
+	"_npmVersion": "3.3.12"
 }

--- a/test/npm3/node_modules/dep3/package.json
+++ b/test/npm3/node_modules/dep3/package.json
@@ -3,5 +3,6 @@
 	"version": "1.0.0",
 	"main": "main",
 	"dependencies": {
+		"component-emitter": "1.1.2"
 	}
 }


### PR DESCRIPTION
When crawling an npm3 file structure, don't overwrite packages in the
context. Previously whenever we found a wrong version we would keep a
reference to that pkg object and then overwrite the object when we found
the correct version. This meant that our context contained duplicate
objects, and some versions were incorrect.

Closes #92 and #72