### PR TITLE
Reuse existing pkgInfo if it exists

### DIFF
--- a/npm-load.js
+++ b/npm-load.js
@@ -116,6 +116,8 @@ var translateConfig = function(loader, packages, options){
 		loader.npm = {};
 		loader.npmPaths = {};
 		loader.globalBrowser = {};
+	}
+	if(!loader.npmParentMap) {
 		loader.npmParentMap = options.npmParentMap || {};
 	}
 	loader.npmPaths.__default = packages[0];

--- a/npm.js
+++ b/npm.js
@@ -25,14 +25,14 @@ if(!System.has("@loader")) {
 exports.translate = function(load){
 	var loader = this;
 
-	var resavePackageInfo = isNode && loader.isEnv &&
-		!loader.isEnv("production");
-
 	// This could be an empty string if the fetch failed.
 	if(load.source == "") {
 		return "define([]);";
 	}
 
+	var resavePackageInfo = isNode && loader.isEnv &&
+		!loader.isEnv("production");
+	var prevPackages = loader.npmContext && loader.npmContext.pkgInfo;
 	var context = {
 		packages: [],
 		loader: this,
@@ -55,7 +55,7 @@ exports.translate = function(load){
 	return crawl.deps(context, pkg, true).then(function(){
 		// clean up packages so everything is unique
 		var names = {};
-		var packages = context.pkgInfo = [];
+		var packages = context.pkgInfo = prevPackages || [];
 		utils.forEach(context.packages, function(pkg, index){
 			if(!packages[pkg.name+"@"+pkg.version]) {
 				if(pkg.browser){

--- a/test/test.js
+++ b/test/test.js
@@ -130,6 +130,18 @@ asyncTest("modules using process.env", function(){
 	}).then(start);
 });
 
+asyncTest("Reuse existing npmContext.pkgInfo", function(){
+	GlobalSystem.npmContext.pkgInfo = [{
+		name: "reuse-test", version: "1.0.0",
+		fileUrl: GlobalSystem.baseURL
+	}];
+	GlobalSystem["delete"]("package.json!npm");
+	GlobalSystem["import"]("package.json!npm").then(function(){
+		var first = GlobalSystem.npmContext.pkgInfo[0];
+		equal(first.name, "reuse-test", "package was reused");
+	}).then(start);
+});
+
 asyncTest("module names", function(){
 	makeIframe("not_relative_main/dev.html");
 });


### PR DESCRIPTION
During the build we will be loading separate bundles that have their own
set of package dependencies. Because for each bundle we will be creating
a separate `package.json!npm` source, none of those will encompass ALL
packages, which is what we need for the build.

Instead each time we load the graph for different bundles we'll reuse
the same pkgInfo (this contains the minimal data needed for each
		package) so that we build a full `package.json!npm` module that
contains all of the source needed.

This is for https://github.com/stealjs/steal-tools/issues/365