### PR TITLE
Add existing package after the initial load is created

### DIFF
--- a/npm-load.js
+++ b/npm-load.js
@@ -192,3 +192,20 @@ var translateConfig = function(loader, packages, options){
 	});
 	setupLiveReload();
 };
+
+/**
+ * @function addExistingPackages
+ * @param {Context} context
+ */
+exports.addExistingPackages = function(context, existingPackages){
+	if(existingPackages) {
+		var packages = context.pkgInfo;
+		utils.forEach(existingPackages, function(pkg){
+			var nameAndVersion = pkg.name + "@" + pkg.version;
+			if(!packages[nameAndVersion]) {
+				packages.push(pkg);
+				packages[nameAndVersion] = true;
+			}
+		});
+	}
+};

--- a/npm.js
+++ b/npm.js
@@ -55,7 +55,7 @@ exports.translate = function(load){
 	return crawl.deps(context, pkg, true).then(function(){
 		// clean up packages so everything is unique
 		var names = {};
-		var packages = context.pkgInfo = prevPackages || [];
+		var packages = context.pkgInfo = [];
 		utils.forEach(context.packages, function(pkg, index){
 			if(!packages[pkg.name+"@"+pkg.version]) {
 				if(pkg.browser){
@@ -74,6 +74,10 @@ exports.translate = function(load){
 			}
 		});
 
-		return npmLoad.makeSource(context, pkg);
+		var source = npmLoad.makeSource(context, pkg);
+
+		npmLoad.addExistingPackages(context, prevPackages);
+
+		return source;
 	});
 };

--- a/test/test.js
+++ b/test/test.js
@@ -137,8 +137,9 @@ asyncTest("Reuse existing npmContext.pkgInfo", function(){
 	}];
 	GlobalSystem["delete"]("package.json!npm");
 	GlobalSystem["import"]("package.json!npm").then(function(){
-		var first = GlobalSystem.npmContext.pkgInfo[0];
-		equal(first.name, "reuse-test", "package was reused");
+		var pkgInfo = GlobalSystem.npmContext.pkgInfo;
+		var pkg = pkgInfo[pkgInfo.length - 1];
+		equal(pkg.name, "reuse-test", "package was reused");
 	}).then(start);
 });
 


### PR DESCRIPTION
During the build we add packages from previous builds (when doing a
		multibuild) so that the generated package.json!npm source
contains all of the package data, but we need to wait until after the
source is created to add these packages.