### PR TITLE
adding extension to System._extensions

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -9,6 +9,9 @@ var isWorker = typeof WorkerGlobalScope !== "undefined" && (self instanceof Work
 var isBrowser = typeof window !== "undefined" && !isNode && !isWorker;
 
 exports.addExtension = function(System){
+	if (System._extensions) {
+		System._extensions.push(exports.addExtension);
+	}
 	/**
 	 * Normalize has to deal with a "tricky" situation.  There are module names like
 	 * "css" -> "css" normalize like normal


### PR DESCRIPTION
This is needed so that when cloning the loader's config, the npm extension will be included in the extensions list. This will be necessary here: https://github.com/stealjs/steal/blob/steal-clone/ext/steal-clone.js#L37-L42