### PR TITLE
Support fallbacking to package.json

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -459,6 +459,10 @@ var utils = {
 			if(nodeModulesIndex >= 0) {
 				return nextSlash>=0 ? address.substr(0, nextSlash) : address;
 			}
+		},
+		basename: function(address){
+			var parts = address.split("/");
+			return parts[parts.length - 1];
 		}
 	},
 	includeInBuild: true

--- a/test/folder_index/node_modules/dep/main.js
+++ b/test/folder_index/node_modules/dep/main.js
@@ -1,1 +1,2 @@
+var pkg = require("./package");
 module.exports = require("./folder");


### PR DESCRIPTION
Some code in the wild does:

```js
require("./package");
```

This will load the `package.json`. We have an existing fallback when a
404 occurs, to load `name/index.js`, so this just adds a second, in the
case where the address is `package.js` we'll try (after
		`package/index.js` fails) to load it as `package.json`. Closes #105 