### PR TITLE
Make sure configDependencies are left on the root package

### DIFF
--- a/npm-load.js
+++ b/npm-load.js
@@ -120,7 +120,7 @@ var translateConfig = function(loader, packages, options){
 	if(!loader.npmParentMap) {
 		loader.npmParentMap = options.npmParentMap || {};
 	}
-	loader.npmPaths.__default = packages[0];
+	var rootPkg = loader.npmPaths.__default = packages[0];
 	var lib = packages[0].system && packages[0].system.directories && packages[0].system.directories.lib;
 
 
@@ -163,8 +163,12 @@ var translateConfig = function(loader, packages, options){
 			// don't set system.main
 			var main = pkg.system.main;
 			delete pkg.system.main;
+			var configDeps = pkg.system.configDependencies;
 			delete pkg.system.configDependencies;
 			loader.config(pkg.system);
+			if(pkg === rootPkg) {
+				pkg.system.configDependencies = configDeps;
+			}
 			pkg.system.main = main;
 
 		}

--- a/test/config_deps/another_dep.js
+++ b/test/config_deps/another_dep.js
@@ -1,0 +1,1 @@
+window.ANOTHER = "another";

--- a/test/config_deps/dev.html
+++ b/test/config_deps/dev.html
@@ -22,9 +22,11 @@
 		}
 
 		System["import"]("package.json!npm").then(function(){
+			var rootPkg = System.npmPaths.__default;
 			if(hasQUnit()) {
 				QUnit.equal(window.DEP, "this is a config dep");
 				QUnit.notEqual(System.configDependencies[0], "my-dep", "An npm dependency's configDependencies should not be part of the configDependencies array.");
+				QUnit.ok(rootPkg.system.configDependencies, "there are config deps in the pkg");
 			} else {
 				console.log(window.DEP);
 			}

--- a/test/config_deps/package.json
+++ b/test/config_deps/package.json
@@ -4,5 +4,8 @@
   "version": "1.0.0",
   "dependencies": {
     "dep": "0.0.1"
+  },
+  "system": {
+    "configDependencies": [ "another_dep" ]
   }
 }


### PR DESCRIPTION
The root package contains `configDependencies`. We need these to be left
on so that in the build when we continually recreate the package.json
source the configDependencies are included in the final source.