### PR TITLE
browser load node like (lib/index.js) if "lib/"

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -256,8 +256,8 @@ var utils = {
 		},
 		main: function(pkg) {
 			return  utils.path.removeJS( 
-				(pkg.system && pkg.system.main) 
-				|| (typeof pkg.browser === "string" && pkg.browser) 
+				(pkg.system && pkg.system.main)
+				|| (typeof pkg.browser === "string" && (utils.path.endsWithSlash(pkg.browser) ? pkg.browser+'index' : pkg.browser) )
 				|| (typeof pkg.jspm === "string" && pkg.jspm) 
 				|| (typeof pkg.jspm === "object" && pkg.jspm.main) 
 				|| pkg.main || 'index' ) ;

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "steal-builtins": "^1.0.0",
     "steal-qunit": "^0.1.1",
     "system-json": "0.0.2",
-    "systemjs": "steal/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
+    "systemjs": "stealjs/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
     "testee": "^0.2.2",
-    "transpile": "steal/transpile#c2aeb23ad82b21fdf7f7da989bccbd6ad04e9f13"
+    "transpile": "stealjs/transpile#c2aeb23ad82b21fdf7f7da989bccbd6ad04e9f13"
   },
   "system": {
     "npmIgnore": [

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "qunit": "~0.7.5",
     "steal": "^0.14.0",
     "steal-builtins": "^1.0.0",
-    "steal-qunit": "bitovi/steal-qunit#master",
+    "steal-qunit": "^0.1.1",
     "system-json": "0.0.2",
-    "systemjs": "bitovi/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
+    "systemjs": "steal/systemjs#b664e4cd359c013acb3445627d1e1e1799424542",
     "testee": "^0.2.2",
-    "transpile": "bitovi/transpile#c2aeb23ad82b21fdf7f7da989bccbd6ad04e9f13"
+    "transpile": "steal/transpile#c2aeb23ad82b21fdf7f7da989bccbd6ad04e9f13"
   },
   "system": {
     "npmIgnore": [

--- a/test/browser-node-like/dev.html
+++ b/test/browser-node-like/dev.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+	<title>SystemJS tests</title>
+</head>
+<body>
+	<script>
+		window.QUnit = window.parent.QUnit;
+		window.removeMyself = window.parent.removeMyself;
+	</script>
+
+	<script src="../../node_modules/systemjs/node_modules/es6-module-loader/dist/es6-module-loader.js"></script>
+	<script src="../../node_modules/systemjs/dist/system.js"></script>
+	<script src="../../node_modules/system-json/json.js"></script>
+	<script src="../system_test_config.js"></script>
+	<script>
+		
+		System.import("package.json!npm").then(function(){
+			System.import(System.main).then(function(main){
+				if(window.QUnit) {
+					QUnit.equal(main, "browser", "index.js loaded");
+					removeMyself();
+				} else {
+					console.log(main);
+				}
+				
+			}, function(e){
+				if(window.QUnit) {
+					QUnit.ok(false, e);
+					removeMyself();
+				} else {
+					console.log(e);
+					setTimeout(function(){
+						throw e;
+					});
+				}
+				
+			});
+			
+			
+		}).then(null, function(err){
+			console.error("Oh no, error!", err, err.stack);
+		});
+	</script>
+</body>
+</html>

--- a/test/browser-node-like/lib/index.js
+++ b/test/browser-node-like/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = "browser";

--- a/test/browser-node-like/main.js
+++ b/test/browser-node-like/main.js
@@ -1,0 +1,1 @@
+module.exports = "node";

--- a/test/browser-node-like/package.json
+++ b/test/browser-node-like/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "browser-node-like",
+  "main": "main",
+  "version": "1.0.0",
+  "browser": "lib/"
+}


### PR DESCRIPTION
fix https://github.com/stealjs/steal/issues/623

@matthewp now add a steal PR with 
```
main: function(pkg) {
			return  utils.path.removeJS( 
				(pkg.system && pkg.system.main) 
				|| (typeof pkg.browser === "string" && (utils.path.endsWithSlash(pkg.browser) ? pkg.browser+'index' : pkg.browser) )
				|| (typeof pkg.jspm === "string" && pkg.jspm) 
				|| (typeof pkg.jspm === "object" && pkg.jspm.main) 
				|| pkg.main || 'index' ) ;
		},
```

in npm-utils.js?