### PR TITLE
Add test helpers

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -183,38 +183,6 @@ exports.addExtension = function(System){
 									 parentAddress, pluginNormalize);
 
 		}
-
-		if(depPkg) {
-			parsedModuleName.version = depPkg.version;
-			// add the main path
-			if(!parsedModuleName.modulePath) {
-				parsedModuleName.modulePath = utils.pkg.main(depPkg);
-			}
-			var moduleName = utils.moduleName.create(parsedModuleName);
-			// Apply mappings, if they exist in the refPkg
-			if(refPkg.system && refPkg.system.map &&
-			   typeof refPkg.system.map[moduleName] === "string") {
-				moduleName = refPkg.system.map[moduleName];
-			}
-			return oldNormalize.call(this, moduleName, parentName,
-									 parentAddress, pluginNormalize);
-		} else {
-			if(utils.pkg.isRoot(this, depPkg)) {
-				// if the current package, we can't? have the
-				// module name look like foo@bar#./zed
-				var localName = parsedModuleName.modulePath ?
-					parsedModuleName.modulePath+(parsedModuleName.plugin? parsedModuleName.plugin: "") :
-					utils.pkg.main(depPkg);
-				return oldNormalize.call(this, localName, parentName,
-										 parentAddress, pluginNormalize);
-			}
-			if(refPkg.browser && refPkg.browser[name]) {
-				return oldNormalize.call(this, refPkg.browser[name], parentName,
-										 parentAddress, pluginNormalize);
-			}
-			return oldNormalize.call(this, name, parentName, parentAddress,
-									 pluginNormalize);
-		}
 	};
 
 	var oldLocate = System.locate;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,69 @@
+
+function Runner(System){
+	this.BaseSystem = System;
+	this.deps = [];
+}
+
+Runner.prototype.clone = function(){
+	var loader = this.loader = this.BaseSystem.clone();
+	loader.npm = {};
+	loader.npmPaths = {};
+
+	this.rootPackage({
+		name: "npm-test",
+		main: "main.js",
+		version: "1.0.0"
+	})
+
+	return this;
+};
+
+Runner.prototype.rootPackage = function(pkg){
+	var loader = this.loader;
+	var fileUrl = pkg.fileUrl = ".";
+
+	loader.npmPaths.__default = pkg;
+	loader.npmPaths[fileUrl] = pkg;
+
+	return this;
+};
+
+Runner.prototype.withPackages = function(packages){
+	// Do something to initialize these packages
+	var deps = this.deps = packages.map(function(pkg){
+		return (pkg instanceof Package) ? pkg : new Package(pkg);
+	});
+
+	var loader = this.loader;
+	var npm = loader.npm;
+	deps.forEach(function(package){
+		var pkg = package.pkg;
+		npm[pkg.name] = pkg;
+		npm[pkg.name+"@"+pkg.version] = pkg;
+	});
+
+	return this;
+};
+
+Runner.prototype.withConfig = function(cfg){
+	this.loader.config(cfg);
+	return this;
+};
+
+function Package(pkg){
+	this.pkg = pkg;
+	this.deps = [];
+}
+
+Package.prototype.deps = function(deps){
+	this.deps = deps;
+	return this;
+};
+
+module.exports = function(System){
+	return {
+		clone: function(){
+			return new Runner(System).clone();
+		}
+	};
+};

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -1,0 +1,61 @@
+var helpers = require("./helpers")(System);
+
+QUnit.module("normalizing");
+
+QUnit.test("basics", function(assert){
+	var done = assert.async();
+
+	System.normalize("foo").then(function(name){
+		assert.equal(name, "foo", "Got the right name");
+		done();
+	});
+});
+
+QUnit.test("normalizes child package names", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "parent",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.withPackages([
+			{
+				name: "child",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		]).loader;
+
+	loader.normalize("child", "parent@1.0.0#main")
+	.then(function(name){
+		assert.equal(name, "child@1.0.0#main", "Normalized to the parent");
+	})
+	.then(done, done);
+});
+
+QUnit.test("a package with .js in the name", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "parent",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.withPackages([
+			{
+				name: "foo.js",
+				main: "foo.js",
+				version: "0.0.1"
+			}
+		]).loader;
+
+	loader.normalize("foo.js", "parent#1.0.0#main")
+	.then(function(name){
+		assert.equal(name, "foo.js@0.0.1#foo", "Correctly normalized");
+	})
+	.then(done, done);
+});
+

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
-QUnit.module("system-npm plugin");
 var GlobalSystem = window.System;
+
+require("./normalize_test");
 
 var makeIframe = function(src){
 	var iframe = document.createElement('iframe');
@@ -11,6 +12,8 @@ var makeIframe = function(src){
 	document.body.appendChild(iframe);
 	iframe.src = src;
 };
+
+QUnit.module("system-npm plugin");
 
 asyncTest("utils.moduleName.create and utils.moduleName.parse", function(){
 	GlobalSystem['import']("npm-utils")


### PR DESCRIPTION
This adds some test helpers that makes it easier to test system-npm,
	 especially normalizing. In the future we'll add stuff to make it
	 easier for fetch and other things. The idea is to mock the loader
	 completely so that we don't need to create mini projects like
	 before. Hopefully this will lead to more complete code coverage.