### PR TITLE
Fix getDependencyMap when there are peerDeps

### DIFF
--- a/test/crawl_test.js
+++ b/test/crawl_test.js
@@ -9,10 +9,6 @@ QUnit.test("Returns the correct dependencies for " +
 	 "name": "angular2",
 	 "version": "2.0.0-beta.12",
 	 "fileUrl": "./node_modules/angular2/package.json",
-	 "dependencies": {},
-	 "devDependencies": {},
-	 "directories": {},
-	 "optionalDependencies": {},
 	 "peerDependencies": {
 	  "es6-shim": "^0.35.0",
 	  "reflect-metadata": "0.1.2",

--- a/test/crawl_test.js
+++ b/test/crawl_test.js
@@ -1,0 +1,27 @@
+var crawl = require("npm-crawl");
+
+QUnit.module("npm-crawl/getDependencyMap");
+
+QUnit.test("Returns the correct dependencies for " +
+		   "a package with peer deps", function(assert){
+
+	var pkg = {
+	 "name": "angular2",
+	 "version": "2.0.0-beta.12",
+	 "fileUrl": "./node_modules/angular2/package.json",
+	 "dependencies": {},
+	 "devDependencies": {},
+	 "directories": {},
+	 "optionalDependencies": {},
+	 "peerDependencies": {
+	  "es6-shim": "^0.35.0",
+	  "reflect-metadata": "0.1.2",
+	  "rxjs": "5.0.0-beta.2",
+	  "zone.js": "^0.6.6"
+	 }
+	};
+
+	var map = crawl.getDependencyMap(System, pkg, false);
+
+	assert.equal(map["rxjs"].name, "rxjs", "correctly mapped peer dep");
+});

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -59,3 +59,41 @@ QUnit.test("a package with .js in the name", function(assert){
 	.then(done, done);
 });
 
+QUnit.test("normalizes a package with peer deps", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "parent",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				dep: "1.0.0",
+				peer: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "dep",
+				main: "main.js",
+				version: "1.0.0",
+				peerDependencies: {
+					peer: "1.0.0"
+				}
+			},
+			{
+				name: "peer",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		]).loader;
+
+		// Delete this so it has to be fetched
+		delete loader.npm.peer;
+
+		loader.normalize("peer", "dep@1.0.0#main")
+		.then(function(name){
+			assert.equal(name, "peer@1.0.0#main", "normalized peer");
+		})
+		.then(done, done);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var GlobalSystem = window.System;
 
+require("./crawl_test");
 require("./normalize_test");
 
 var makeIframe = function(src){


### PR DESCRIPTION
`crawl.getDependencyMap` was failing when there are multiple peer deps
because the same object was being reused to set options on each peer
dep.