### PR TITLE
Handle progressively loading package.jsons with same version

### DIFF
--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -53,6 +53,8 @@ var crawl = {
 			return context.fetchCache[versionAndRange];
 		}
 
+		childPkg = utils.extend({}, childPkg);
+
 		var p = context.fetchCache[versionAndRange] =
 			crawl.fetchDep(context, pkg, childPkg, isRoot);
 
@@ -62,6 +64,8 @@ var crawl = {
 				var fetchedPkg = crawl.matchedVersion(context, childPkg.name,
 													  childPkg.version);
 				return fetchedPkg;
+			} else {
+				childPkg = result;
 			}
 
 			// Save this pkgInfo into the context

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -97,3 +97,56 @@ QUnit.test("normalizes a package with peer deps", function(assert){
 		})
 		.then(done, done);
 });
+
+QUnit.test("Can load two separate versions of same package", function(assert){
+	var done = assert.async();
+	var Package = helpers.Package;
+
+	var loader = helpers.clone()
+		.npmVersion(3)
+		.rootPackage({
+			name: "parent",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				"fixture": "1.0.0",
+				"connect": "1.0.0"
+			}
+		})
+		.withPackages([
+			new Package({
+				name: "fixture",
+				main: "main.js",
+				version: "1.0.0",
+				dependencies: {
+					"set": "^3.0.0"
+				}
+			}).deps([
+				new Package({
+					name: "set",
+					main: "main.js",
+					version: "3.0.4"
+				}, false)
+			]),
+			{
+				name: "connect",
+				main: "main.js",
+				version: "1.0.0",
+				dependencies: {
+					"set": "^5.0.0"
+				}
+			},
+			new Package({
+				name: "set",
+				main: "main.js",
+				version: "5.0.4"
+			}, false)
+		])
+		.loader;
+
+	loader.normalize("set", "fixture@1.0.0#main")
+	.then(function(name){
+		assert.equal(name, "set@3.0.4#main", "Got the correct version of set");
+	})
+	.then(done, done);
+});


### PR DESCRIPTION
Came across a bug where when 2 dependencies have a common dep with
different versions and both are being progressively fetched, it would
not resolve with the correct package.json in both scenarios. The
corresponding test shows the scenario.