### PR TITLE
process.cwd() should return a string.

### DIFF
--- a/npm-load.js
+++ b/npm-load.js
@@ -104,7 +104,9 @@ var translateConfig = function(loader, packages, options){
 	var g = loader.global;
 	if(!g.process) {
 		g.process = {
-			cwd: function(){},
+			cwd: function(){
+				return "/";
+			},
 			browser: true,
 			env: {
 				NODE_ENV: loader.env


### PR DESCRIPTION
If `process.cwd()` returns undefined, it breaks node's `path` module when it's used in the browser.  This polyfill for process.cwd now matches the one in the babel polyfill here: https://github.com/stealjs/steal/blob/master/ext/babel-polyfill.js#L55

You can test for this by importing the path module in a project then doing
```js
path.resolve(process.cwd(), '401.html');  // Should match the next line
path.resolve('/', '401.html');

path.resolve(undefined, '401.html');  // Throws an error
```