### PR TITLE
Handle browserify array properties

### DIFF
--- a/npm-convert.js
+++ b/npm-convert.js
@@ -243,10 +243,18 @@ function convertBrowser(pkg, browser) {
 function convertBrowserProperty(map, pkg, fromName, toName) {
 	var packageName = pkg.name;
 
-	var fromParsed = utils.moduleName.parse(fromName, packageName),
-		  toParsed = toName  ? utils.moduleName.parse(toName, packageName): "@empty";
+	var fromParsed = utils.moduleName.parse(fromName, packageName);
+	var toResult = toName;
 
-	map[utils.moduleName.create(fromParsed)] = utils.moduleName.create(toParsed);
+	if(!toName || typeof toName === "string") {
+		var toParsed = toName ? utils.moduleName.parse(toName, packageName)
+			: "@empty";
+		toResult = utils.moduleName.create(toParsed);
+	} else if(utils.isArray(toName)) {
+		toResult = toName;
+	}
+	
+	map[utils.moduleName.create(fromParsed)] = toResult;
 }
 
 function convertJspm(pkg, jspm){

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -23,3 +23,54 @@ QUnit.test("process.cwd()", function(assert){
 	})
 	.then(done, done);
 });
+
+QUnit.module("Importing npm modules using 'browser' config");
+
+QUnit.test("Array property value", function(assert){
+	var done = assert.async();
+
+	var appModule = "module.exports = 'bar';";
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			browserify: {
+				transform: [
+					"loose-envify"
+				]
+			}
+		})
+		.withModule("app@1.0.0#main", appModule)
+		.loader;
+
+	loader["import"]("app")
+	.then(function(app){
+		assert.equal(app, "bar", "loaded the app");
+	})
+	.then(done, done);
+});
+
+QUnit.test("Specifies a different main", function(assert){
+	var done = assert.async();
+
+	var appModule = "module.exports = 'bar';";
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			browserify: "app.js"
+		})
+		.withModule("app@1.0.0#app", appModule)
+		.loader;
+
+	loader["import"]("app")
+	.then(function(app){
+		assert.equal(app, "bar", "loaded the app");
+	})
+	.then(done, done);
+
+});


### PR DESCRIPTION
Browserify has an array property `transform` that we were treating as a
moduleName. Updating the logic to properly handle this scenario, by just
copying the config over as is.

Closes #128