### PR TITLE
Don't retry when failing to fetch a package.json

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -243,8 +243,10 @@ exports.addExtension = function(System){
 		}
 
 		var loader = this;
-		return Promise.resolve(oldFetch.apply(this, arguments))
-			.then(null, function(){
+		var fetchPromise = Promise.resolve(oldFetch.apply(this, arguments));
+
+		if(utils.moduleName.isNpm(load.name)) {
+			fetchPromise = fetchPromise.then(null, function(err){
 				return tryWith("/index").then(null, function(err){
 					if(utils.moduleName.isNpm(load.name) &&
 					   utils.path.basename(load.address) === "package.js") {
@@ -281,6 +283,9 @@ exports.addExtension = function(System){
 
 				}
 			});
+		}
+
+		return fetchPromise;
 	};
 
 	// Given a moduleName convert it into a npm-style moduleName if it belongs

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -72,5 +72,51 @@ QUnit.test("Specifies a different main", function(assert){
 		assert.equal(app, "bar", "loaded the app");
 	})
 	.then(done, done);
-
 });
+
+QUnit.module("Importing packages with /index convention");
+
+QUnit.test("Retries with /index", function(assert){
+	var done = assert.async();
+
+	var appModule = "module.exports = { worked: true };";
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.withModule("app@1.0.0#foo/index", appModule)
+		.loader;
+
+	loader["import"]("app/foo")
+	.then(function(mod){
+		assert.ok(mod.worked, "it loaded the index variant");
+	})
+	.then(done, done);
+});
+
+QUnit.test("Doesn't retry non-npm module names", function(assert){
+	var done = assert.async();
+
+	var appModule = "module.exports = { worked: true };";
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.withModule("node_modules/foo/package.json/index", "module.exports={}")
+		.loader;
+
+	var retried = false;
+
+	loader["import"]("node_modules/foo/package.json")
+	.then(null, function(err){
+		assert.ok(err, "Got an error, didn't retry");
+	})
+	.then(done, done);
+});
+


### PR DESCRIPTION
Currently we are retrying to fetch a package.json. We are retry for the
/index convention. However, we should only be retrying in the case where
the module name is an npm module name.