### PR TITLE
Late-bound config should only be applied to loaded pkg

### DIFF
--- a/test/steal.html
+++ b/test/steal.html
@@ -18,6 +18,7 @@
 			paths: {
 				"npm": "npm.js",
 				"npm-extension": "npm-extension.js",
+				"npm-convert": "npm-convert.js",
 				"npm-crawl": "npm-crawl.js",
 				"npm-utils": "npm-utils.js"
 			}


### PR DESCRIPTION
When config is late-bound (meaning it is waiting on a package.json to
		load) we should only be applying the config for the package that
loaded. Previously we were applying all of the config again. This means
that we might have overrided config, making it non-deterministic.