### PR TITLE
Support npm convention relative to folder

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -65,6 +65,24 @@ exports.addExtension = function(System){
 									 pluginNormalize);
 		}
 
+		// If name is ./ or ../
+		var isPointingAtParentFolder = name === "../" || name === "./";
+
+		if(parentIsNpmModule && isPointingAtParentFolder) {
+			var parsedParentModuleName = utils.moduleName.parse(parentName);
+			var parentModulePath = parsedParentModuleName.modulePath || "";
+			var relativePath = utils.path.relativeTo(parentModulePath, name);
+			var isInRoot = utils.path.isPackageRootDir(relativePath);
+
+			if(isInRoot) {
+				name = refPkg.name + "#" + utils.path.removeJS(refPkg.main);
+
+			} else {
+				name = name + "index";
+			}
+		}
+
+
 		// Using the current package, get info about what it is probably asking for
 		var parsedModuleName = utils.moduleName.parseFromPackage(this, refPkg,
 																 name,
@@ -79,7 +97,6 @@ exports.addExtension = function(System){
 			parentIsNpmModule &&
 			nameIsRelative &&
 			parsedPackageNameIsReferringPackage;
-
 
 		// Look for the dependency package specified by the current package
 		var depPkg, wantedPkg;

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -491,6 +491,18 @@ var utils = {
 		basename: function(address){
 			var parts = address.split("/");
 			return parts[parts.length - 1];
+		},
+		relativeTo: function(modulePath, rel) {
+			var parts = modulePath.split("/");
+			var idx = 1;
+			while(rel[idx] === ".") {
+				parts.pop();
+				idx++;
+			}
+			return parts.join("/");
+		},
+		isPackageRootDir: function(pth) {
+			return pth.indexOf("/") === -1;
 		}
 	},
 	includeInBuild: true


### PR DESCRIPTION
This supports all of the possible npm relative paths that point to
folders. This supports:

1. Pointing at a folder in a parent module like `../` which resolve to
`../index`.
2. Pointing at a folder in the same dir like './` which resolves to
`./index`.
3. Pointing at a folder when in the parent-most folder, which resolves
to the pkg.main.

Closes #132