### PR TITLE
Always save version range configuration after loading a package.json

### DIFF
--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -157,6 +157,9 @@ var crawl = {
 					});
 					return finishLoad(newCopy);
 				}
+
+				crawl.setVersionsConfig(context, lpkg, copy.version);
+
 				return lpkg;
 			});
 		}
@@ -339,6 +342,13 @@ var crawl = {
 		loader.npm[pkg.name+"@"+pkg.version] = pkg;
 		var pkgAddress = pkg.fileUrl.replace(/\/package\.json.*/,"");
 		loader.npmPaths[pkgAddress] = pkg;
+	},
+	setVersionsConfig: function(context, pkg, versionRange) {
+		if(!context.versions[pkg.name]) {
+			context.versions[pkg.name] = {};
+		}
+		var versions = context.versions[pkg.name];
+		versions[versionRange] = pkg;
 	},
 	pkgSatisfies: function(pkg, versionRange) {
 		return SemVer.validRange(versionRange) ?

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -113,7 +113,7 @@ Runner.prototype.withPackages = function(packages){
 
 		var fileUrl = "./node_modules/" + pkg.name;
 
-		if(parentPackage && runner.packagePaths[fileUrl]) {
+		if(parentPackage && runner.packagePaths[fileUrl + "/package.json"]) {
 			fileUrl = parentFileUrl + "/node_modules/" + pkg.name;
 		}
 

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -154,6 +154,54 @@ QUnit.test("Can load two separate versions of same package", function(assert){
 	.then(done, done);
 });
 
+QUnit.test("Configures a package when conflicting package.jsons are progressively loaded", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.npmVersion(3)
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js",
+			dependencies: {
+				"steal-focha": "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "focha",
+				version: "1.0.0",
+				main: "main.js"
+			},
+			new Package({
+				name: "steal-focha",
+				version: "1.0.0",
+				main: "main.js",
+				dependencies: {
+					"focha": "^2.0.0"
+				},
+				system: {
+					map: {
+						focha: "focha#./other"
+					}
+				}
+			}).deps([
+				{
+					name: "focha",
+					version: "2.0.0",
+					main: "main.js"
+				}
+			])
+		])
+		.loader;
+
+	loader.normalize("focha", "steal-focha@1.0.0#main")
+	.then(function(name){
+		assert.equal(name, "focha@2.0.0#other", "config applied");
+	})
+	.then(done, done);
+});
+
 QUnit.test("Loads npm convention of folder with trailing slash", function(assert){
 	var done = assert.async();
 


### PR DESCRIPTION
We have a map that uses a versionRange as the key and a package.json as
the value. In a scenario where we have to load more than one
package.json (because one in the wrong place) we need to make sure this
versions map is updated so that config is correctly applied.