### PR TITLE
Refactor retry code

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -33,6 +33,7 @@ exports.addExtension = function(System){
 		var hasNoParent = !parentName;
 		var nameIsRelative = utils.path.isRelative(name);
 		var parentIsNpmModule = utils.moduleName.isNpm(parentName);
+		var identifierEndsWithSlash = utils.path.endsWithSlash(name);
 
 		// If this is a relative module name and the parent is not an npm module
 		// we can skip all of this logic.
@@ -202,8 +203,18 @@ exports.addExtension = function(System){
 			   typeof refPkg.system.map[moduleName] === "string") {
 				moduleName = refPkg.system.map[moduleName];
 			}
-			return oldNormalize.call(loader, moduleName, parentName,
-									 parentAddress, pluginNormalize);
+			var p = oldNormalize.call(loader, moduleName, parentName,
+									  parentAddress, pluginNormalize);
+
+			// For identifiers like ./lib/ save this info as we might
+			// get a 404 and need to retry with lib/index.js
+			if(identifierEndsWithSlash) {
+				p.then(function(name){
+					context.forwardSlashMap[name] = true;
+				});
+			}
+
+			return p;
 
 		}
 	};
@@ -260,44 +271,32 @@ exports.addExtension = function(System){
 		}
 
 		var loader = this;
+		var context = loader.npmContext;
 		var fetchPromise = Promise.resolve(oldFetch.apply(this, arguments));
 
 		if(utils.moduleName.isNpm(load.name)) {
 			fetchPromise = fetchPromise.then(null, function(err){
-				return tryWith("/index").then(null, function(err){
-					if(utils.moduleName.isNpm(load.name) &&
-					   utils.path.basename(load.address) === "package.js") {
-						// This is package.js, try as package.json
-						return tryWith(".json");
+				// Begin attempting retries. `retryTypes` defines different
+				// types of retries to do, currently retrying on the
+				// /index and /package.json conventions.
+				var types = [].slice.call(retryTypes);
+
+				return retryAll(types, err);
+				
+				function retryAll(types, err){
+					if(!types.length) {
+						throw err;
 					}
-					throw err;
-				});
 
-				function tryWith(addedPart){
-					var local = utils.extend({}, load);
-					local.name = load.name + addedPart;
-					local.metadata = { dryRun: true };
+					var type = types.shift();
+					if(!type.test(load)) {
+						throw err;
+					}
 
-					return Promise.resolve(loader.locate(local))
-						.then(function(address){
-							local.address = address;
-							return loader.fetch(local);
-						})
-						.then(function(source){
-							load.address = local.address;
-							loader.npmParentMap[load.name] = local.name;
-							var npmLoad = loader.npmContext &&
-								loader.npmContext.npmLoad;
-							if(npmLoad) {
-								npmLoad.saveLoadIfNeeded(loader.npmContext);
-								utils.warnOnce("Some 404s were encountered " +
-											   "while loading. Don't panic! " +
-											   "These will only happen in dev " +
-											   "and are harmless.");
-							}
-							return source;
-						});
-
+					return Promise.resolve(retryFetch.call(loader, load, type))
+					.then(null, function(err){
+						return retryAll(types, err);
+					});
 				}
 			});
 		}
@@ -358,4 +357,63 @@ exports.addExtension = function(System){
 		}
 		oldConfig.apply(loader, arguments);
 	};
+
+	function retryFetch(load, type) {
+		var loader = this;
+
+		// Get the new moduleName to test against
+		var moduleName = typeof type.name === "function" ?
+			type.name(loader, load) :
+			load.name + type.name;
+
+		var local = utils.extend({}, load);
+		local.name = moduleName;
+		local.metadata = { dryRun: true };
+
+		return Promise.resolve(loader.locate(local))
+			.then(function(address){
+				local.address = address;
+				return loader.fetch(local);
+			})
+			.then(function(source){
+				load.address = local.address;
+				loader.npmParentMap[load.name] = local.name;
+				var npmLoad = loader.npmContext &&
+					loader.npmContext.npmLoad;
+				if(npmLoad) {
+					npmLoad.saveLoadIfNeeded(loader.npmContext);
+					if(!isNode) {
+						utils.warnOnce("Some 404s were encountered " +
+									   "while loading. Don't panic! " +
+									   "These will only happen in dev " +
+									   "and are harmless.");
+					}
+				}
+				return source;
+			});
+	}
+
+	// These define ways to retry a fetch when it fails (404)
+	var retryTypes = [
+		{
+			name: function(loader, load){
+				var context = loader.npmContext;
+				if(context.forwardSlashMap[load.name]) {
+					var parts = load.name.split("/");
+					parts.pop();
+					return parts.concat(["index"]).join("/");
+				}
+
+				return load.name + "/index";
+			},
+			test: function() { return true; }
+		},
+		{
+			name: ".json",
+			test: function(load){
+				return utils.moduleName.isNpm(load.name) &&
+					utils.path.basename(load.address) === "package.js";
+			}
+		}
+	];
 };

--- a/npm.js
+++ b/npm.js
@@ -38,7 +38,8 @@ exports.translate = function(load){
 		deferredConversions: {},
 		npmLoad: npmLoad,
 		crawl: crawl,
-		resavePackageInfo: resavePackageInfo
+		resavePackageInfo: resavePackageInfo,
+		forwardSlashMap: {}
 	};
 	this.npmContext = context;
 	var pkg = {origFileUrl: load.address, fileUrl: utils.relativeURI(loader.baseURL, load.address)};

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -120,6 +120,25 @@ QUnit.test("Retries with /index", function(assert){
 	.then(done, done);
 });
 
+QUnit.test("Retries /package convention as well", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.withModule("app@1.0.0#package.json", "module.exports = 'works'")
+		.loader;
+
+	loader["import"]("./package", { name : "app@1.0.0#main" })
+	.then(function(mod){
+		assert.equal(mod, "works", "loaded the package.json");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 QUnit.test("Doesn't retry non-npm module names", function(assert){
 	var done = assert.async();
 
@@ -141,6 +160,25 @@ QUnit.test("Doesn't retry non-npm module names", function(assert){
 		assert.ok(err, "Got an error, didn't retry");
 	})
 	.then(done, done);
+});
+
+QUnit.test("Retries when using the forward slash convention", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.withModule("app@1.0.0#lib/index", "module.exports = 'works'")
+		.loader;
+
+	loader["import"]("./lib/", { name: "app@1.0.0#main" })
+	.then(function(mod){
+		assert.equal(mod, "works", "imported the module");
+	})
+	.then(done, helpers.fail(assert, done));
 });
 
 QUnit.module("Importing globalBrowser config");


### PR DESCRIPTION
This refactors retry code and fixes one scenario: `./lib/` that should
point to `packageName/lib/index`. Since we use the forward-slash as a
Steal convention we need to capture this as a retry.