### PR TITLE
Refactor fetching package.jsons

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -31,8 +31,10 @@ exports.translate = function(load){
 	var context = {
 		packages: [],
 		loader: this,
-		// places we
+		// places we load package.jsons from
 		paths: {},
+		// paths that are currently be loaded
+		loadingPaths: {},
 		versions: {},
 		fetchCache: {},
 		deferredConversions: {},

--- a/test/crawl_test.js
+++ b/test/crawl_test.js
@@ -1,4 +1,8 @@
 var crawl = require("npm-crawl");
+var helpers = require("./helpers")(System);
+var utils = require("../npm-utils");
+
+var FetchTask = crawl.FetchTask;
 
 QUnit.module("npm-crawl/getDependencyMap");
 
@@ -20,4 +24,194 @@ QUnit.test("Returns the correct dependencies for " +
 	var map = crawl.getDependencyMap(System, pkg, false);
 
 	assert.equal(map["rxjs"].name, "rxjs", "correctly mapped peer dep");
+});
+
+QUnit.module("npm-crawl/FetchTask");
+
+QUnit.test("loads a package.json", function(assert){
+	var reset = helpers.hookFetch({
+		"./node_modules/app/package.json": {
+			name: "app",
+			version: "1.1.0",
+			main: "main.js"
+		}
+	});
+
+	var done = helpers.done(assert.async(), reset);
+
+	var pkg = {
+		name: "app",
+		version: "^1.0.0",
+		origFileUrl: "./node_modules/app/package.json"
+	};
+
+	var task = new FetchTask(helpers.makeContext(), pkg)
+	task.load()
+	.then(function(){
+		var pkg = task.getPackage();
+		assert.equal(utils.pkg.main(pkg), "main");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("First load fails and the load for the nextFileUrl is loading",
+		   function(assert){
+	var reset = helpers.hookFetch({
+		"./node_modules/app/package.json": {
+			name: "app",
+			version: "1.1.0",
+			main: "main.js"
+		}
+	});
+	var done = helpers.done(assert.async(), reset);
+
+	var pkgOne = {
+		name: "app",
+		version: "^1.0.0",
+		origFileUrl: "./node_modules/foo/node_modules/app/package.json"
+	};
+
+	var pkgTwo = {
+		name: "app",
+		version: "^1.0.0",
+		origFileUrl: "./node_modules/app/package.json"
+	};
+
+	var context = helpers.makeContext();
+
+	var task = new FetchTask(context, pkgOne);
+	task.load()
+	.then(function(){
+		assert.equal(task.failed, true, "The first task failed");
+
+		// Start a new task for the real location.
+		new FetchTask(context, pkgTwo).load();
+
+		// Now create a new task for the next location and try to load it.
+		var nextPkg = task.next();
+		task = new FetchTask(context, nextPkg);
+		return task.load();
+	})
+	.then(function(){
+		assert.equal(task.failed, false, "Task did not fail again");
+
+		var pkg = task.getPackage();
+		assert.equal(pkg.version, "1.1.0", "Loaded the correct version");
+		assert.ok(!context.loadingPaths[task.pkg.fileUrl], "Task is removed " +
+				  "from the context");
+	})
+	.then(done, done);
+});
+
+QUnit.test("First load fails and the load for the nextFileUrl is complete and semver compatible",
+		   function(assert){
+	var reset = helpers.hookFetch({
+		"./node_modules/app/package.json": {
+			name: "app",
+			version: "1.1.0",
+			main: "main.js"
+		}
+	});
+	var done = helpers.done(assert.async(), reset);
+
+	var pkgOne = {
+		name: "app",
+		version: "^1.0.0",
+		origFileUrl: "./node_modules/foo/node_modules/app/package.json"
+	};
+
+	var pkgTwo = {
+		name: "app",
+		version: "^1.0.0",
+		origFileUrl: "./node_modules/app/package.json"
+	};
+
+	var context = helpers.makeContext();
+
+	var task = new FetchTask(context, pkgOne);
+	task.load()
+	.then(function(){
+		assert.equal(task.failed, true, "The first task failed");
+
+		// Start a new task for the real location.
+		// Wait for it to finish so that the retry below will
+		// find a loaded version ready to go.
+		return new FetchTask(context, pkgTwo).load()
+		.then(function(){
+			// Now create a new task for the next location and try to load it.
+			var nextPkg = task.next();
+			task = new FetchTask(context, nextPkg);
+			return task.load();
+		});
+	})
+	.then(function(){
+		assert.equal(task.failed, false, "Task did not fail again");
+
+		var pkg = task.getPackage();
+		assert.equal(pkg.version, "1.1.0", "Loaded the correct version");
+	})
+	.then(done, done);
+});
+
+QUnit.test("First load fails and the load for the nextFileUrl is complete and not semver compatible",
+		   function(assert){
+	var reset = helpers.hookFetch({
+		"./node_modules/app/package.json": {
+			name: "app",
+			version: "1.1.0",
+			main: "main.js"
+		},
+		"./node_modules/foo/node_modules/app/package.json": {
+			name: "app",
+			version: "2.0.0",
+			main: "main.js"
+		}
+	});
+	var done = helpers.done(assert.async(), reset);
+
+	var pkgOne = {
+		name: "app",
+		version: "^1.0.0",
+		origFileUrl: "./node_modules/foo/node_modules/bar/node_modules/app/package.json"
+	};
+
+	var pkgTwo = {
+		name: "app",
+		version: "^2.0.0",
+		origFileUrl: "./node_modules/foo/node_modules/app/package.json"
+	};
+
+	var context = helpers.makeContext();
+
+	var task = new FetchTask(context, pkgOne);
+	task.load()
+	.then(function(){
+		assert.equal(task.failed, true, "The first task failed");
+
+		// Start a new task for the real location.
+		// Wait for it to finish so that the retry below will
+		// find a loaded version that is semver incompatible
+		return new FetchTask(context, pkgTwo).load()
+		.then(function(){
+			// Now create a new task for the next location and try to load it.
+			var nextPkg = task.next();
+			task = new FetchTask(context, nextPkg);
+			return task.load();
+		});
+	})
+	.then(function(){
+		assert.equal(task.failed, true, "Task failed again, an incompatible version");
+
+		var nextPkg = task.next();
+		task = new FetchTask(context, nextPkg);
+		return task.load();
+	})
+	.then(function(){
+		assert.equal(task.failed, false, "Task did not fail again");
+
+		var pkg = task.getPackage();
+		assert.equal(pkg.version, "1.1.0", "Loaded the correct version");
+	})
+	.then(done, done);
+
 });

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -233,7 +233,7 @@ QUnit.test("Correctly imports globalBrowser package that is depended on by anoth
 					"http": "http"
 				},
 				dependencies: {
-					"http": "~0.0.0"
+					"http": "0.10.0"
 				}
 			},
 			{


### PR DESCRIPTION
This refactor is to handle all conditions that can occur when loading a
package.json. These are:

1) A package has already been loaded from that url and is not semver
compatible.
2) A package has already been loaded from that url and is semver
compatible.
3) A package is currently loading from that url (wait for it to
	complete).
4) A package hasn't been loaded (and is not being loaded) from that url,
	let's load it ourselves.

Fixes #142