### PR TITLE
make tilde operator work

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -82,8 +82,7 @@ exports.addExtension = function(System){
 				name = name + "index";
 			}
 		}
-
-
+		
 		// Using the current package, get info about what it is probably asking for
 		var parsedModuleName = utils.moduleName.parseFromPackage(this, refPkg,
 																 name,

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -152,7 +152,6 @@ var utils = {
 		 * @return {system-npm/parsed_npm}
 		 */
 		parse: function (moduleName, currentPackageName, global) {
-			// debugger;
 			var pluginParts = moduleName.split('!');
 			var modulePathParts = pluginParts[0].split("#");
 			var versionParts = modulePathParts[0].split("@");
@@ -177,7 +176,6 @@ var utils = {
 				// if the module name starts with the ~ (tilde) operator
 				// use the currentPackageName
 			} else if (currentPackageName && utils.path.startsWithTildeSlash(moduleName)) {
-				debugger;
 				packageName = currentPackageName;
 				modulePath = versionParts[0].split("/").slice(1).join("/");
 

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -152,6 +152,7 @@ var utils = {
 		 * @return {system-npm/parsed_npm}
 		 */
 		parse: function (moduleName, currentPackageName, global) {
+			// debugger;
 			var pluginParts = moduleName.split('!');
 			var modulePathParts = pluginParts[0].split("#");
 			var versionParts = modulePathParts[0].split("@");
@@ -167,10 +168,19 @@ var utils = {
 			var packageName,
 				modulePath;
 
-			// if relative, use currentPackageName
-			if( currentPackageName && utils.path.isRelative(moduleName) ) {
-				packageName= currentPackageName;
+			// if the module name is relative
+			// use the currentPackageName
+			if (currentPackageName && utils.path.isRelative(moduleName)) {
+				packageName = currentPackageName;
 				modulePath = versionParts[0];
+
+				// if the module name starts with the ~ (tilde) operator
+				// use the currentPackageName
+			} else if (currentPackageName && utils.path.startsWithTildeSlash(moduleName)) {
+				debugger;
+				packageName = currentPackageName;
+				modulePath = versionParts[0].split("/").slice(1).join("/");
+
 			} else {
 
 				if(modulePathParts[1]) { // foo@1.2#./path
@@ -433,6 +443,9 @@ var utils = {
 		},
 		isRelative: function(path) {
 			return  path.substr(0,1) === ".";
+		},
+		startsWithTildeSlash: function( path ) {
+			return path.substr(0,2) === "~/";
 		},
 		joinURIs: function(base, href) {
 			function removeDotSegments(input) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "~2.4.1",
     "qunit": "~0.7.5",
     "qunitjs": "^1.22.0",
-    "steal": "^0.16.0",
+    "steal": "^1.0.0-pre.0",
     "steal-builtins": "^1.0.0",
     "steal-conditional": "^0.1.2",
     "steal-qunit": "^0.1.1",


### PR DESCRIPTION
close https://github.com/stealjs/steal/issues/719

possible imports are:
```
import "~/foo/foobar";
import "~/./foo/foobar";
```

main advantage is, you can now share modules and dont have to point to the package-name.

you can have a dependency package **dep**  with the following modules
**dep1@1.0.0#foobar**
```
module.exports = 'works';
```

**dep1@1.0.0#main**
```
module.exports = require('~/foobar');
```
**app@1.0.0#main**
```
var out = require('dep1/main');
```

`require('~/foobar')` within `dep1@1.0.0#main` points to `dep1@1.0.0#foobar` because the ~ (tilde) operator remember the package

@matthewp i think i can explain the behavior not so good... can you try to write a docomentation?