### PR TITLE
Correctly find refPkg when project is within a node_modules folder

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -331,7 +331,13 @@ var utils = {
 					}
 				}
 				if(moduleAddress) {
-					var packageFolder = utils.pkg.folderAddress(moduleAddress);
+					// Remove the baseURL so that folderAddress only detects
+					// node_modules that are within the baseURL. Otherwise
+					// you cannot load a project that is itself within
+					// node_modules
+					var startingAddress = utils.relativeURI(loader.baseURL,
+															moduleAddress);
+					var packageFolder = utils.pkg.folderAddress(startingAddress);
 					return packageFolder ? loader.npmPaths[packageFolder] : utils.pkg.getDefault(loader);
 				} else {
 					return utils.pkg.getDefault(loader);

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -47,6 +47,45 @@ QUnit.test("Allows a relative main", function(assert){
 	.then(done, done);
 });
 
+QUnit.test("A project within a node_modules folder", function(assert){
+	var done = assert.async();
+
+	var main = "module.exports = require('dep');";
+	var dep = "module.exports = 'works';";
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js",
+			dependencies: {
+				dep: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "dep",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])
+		.withConfig({
+			baseURL: "http://example.com/node_modules/project/something/else/"
+		})
+		.withModule("main", main)
+		.withModule("dep@1.0.0#main", dep)
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader["import"](loader.main);
+	})
+	.then(function(val){
+		assert.equal(val, "works", "able to load a project within a node_modules folder");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 QUnit.module("Importing npm modules using 'browser' config");
 
 QUnit.test("Array property value", function(assert){


### PR DESCRIPTION
If a project is running from within a node_modules folder the
`System.baseURL` will contain the string "node_modules". When looking up
the refPkg we detect this by looking for "node_modules". We really want
to know if we are within the *project's* own node_modules folder.

Closes #149