### PR TITLE
Make packages that look up themselves work

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -133,9 +133,15 @@ exports.addExtension = function(System){
 			}
 		}
 
+		// If the parent package is loading itself by name, look up by version
+		if(parsedPackageNameIsReferringPackage) {
+			depPkg = utils.pkg.findByNameAndVersion(this,
+													parsedModuleName.packageName,
+													refPkg.version);
+		}
+
 		// This really shouldn't happen, but lets find a package.
-		var lookupByName = parsedModuleName.isGlobal || hasNoParent ||
-			parsedPackageNameIsReferringPackage;
+		var lookupByName = parsedModuleName.isGlobal || hasNoParent;
 		if (!depPkg) {
 			depPkg = utils.pkg.findByName(this, parsedModuleName.packageName);
 		}

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -384,6 +384,12 @@ var utils = {
 				return loader.npm[name];
 			}
 		},
+		findByNameAndVersion: function(loader, name, version) {
+			if(loader.npm && !utils.path.startsWithDotSlash(name)) {
+				var nameAndVersion = name + "@" + version;
+				return loader.npm[nameAndVersion];
+			}
+		},
 		findByUrl: function(loader, url) {
 			if(loader.npm) {
 				url = utils.pkg.folderAddress(url);


### PR DESCRIPTION
When you have a package like:

```
{
  "name": "connect"
}
```

With code like:

```js
require("connect/foo/bar");
```

It is looking up itself, so we need to check that we find the correct
package by looking for the package name AND version, not just the name.