### PR TITLE
Conditionally adds a dependency on the Node Buffer

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -305,6 +305,30 @@ exports.addExtension = function(System){
 		return fetchPromise;
 	};
 
+	// Trying to detect the use of global Buffer; doesn't contain something like
+	// var Buffer or let Buffer
+	var bufferGlobalExp = /^(?!.*(var|let|const) Buffer)(.*Buffer)/;
+
+	// Override 'translate' to add Node global shims.
+	function insertNodeGlobals(loader, load) {
+		return loader.insertNodeGlobals !== false &&
+			load.metadata.insertNodeGlobals !== false;
+	}
+
+	var oldTranslate = System.translate;
+	System.translate = function(load){
+		// Only insert the globals if not turned off for this module
+		// or globally
+		if(insertNodeGlobals(this, load)) {
+			var usesBufferGlobal = bufferGlobalExp.test(load.source);
+			if(usesBufferGlobal) {
+				load.source = "(function(Buffer){\n" + load.source +
+					"\n})(require(\"buffer\").Buffer);";
+			}
+		}
+		return oldTranslate.apply(this, arguments);
+	};
+
 	// Given a moduleName convert it into a npm-style moduleName if it belongs
 	// to a package.
 	var convertName = function(loader, name){

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ require("./utils_test");
 require("./crawl_test");
 require("./normalize_test");
 require("./import_test");
+require("./translate_test");
 
 var makeIframe = function(src){
 	var iframe = document.createElement('iframe');

--- a/test/translate_test.js
+++ b/test/translate_test.js
@@ -1,0 +1,90 @@
+var helpers = require("./helpers")(System);
+var utils = require("npm-utils");
+var forEach = utils.forEach;
+
+QUnit.module("Translating npm modules");
+
+QUnit.test("Adds Buffer global when used", function(assert){
+	var done = assert.async();
+
+	var tests = [
+		{
+			source: "var Buffer = 'foo';",
+			included: false
+		},
+		{
+			source: "let Buffer = 'foo';",
+			included: false
+		},
+		{
+			source: "const Buffer = 'foo';",
+			included: false
+		},
+		{
+			source: "var foo = new Buffer()",
+			included: true
+		},
+		{
+			source: "var none = 'any buffer at all';",
+			included: false
+		}
+	];
+
+	var loader = helpers.clone().loader;
+
+	var promises = utils.map(tests, function(test){
+		return loader.translate({
+			name: 'some-id',
+			address: 'foo://bar',
+			metadata: {},
+			source: test.source
+		}).then(function(src){
+			var included = /require/.test(src);
+			assert.equal(included, test.included,
+						 "Buffer was added (or not added)");
+		});
+	});
+
+	Promise.all(promises)
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("Doesn't add buffer when loader.insertNodeGlobals is false", function(assert){
+	var done = assert.async();
+	var loader = helpers.clone()
+		.withConfig({
+			insertNodeGlobals: false
+		})
+		.loader;
+
+	loader.translate({
+		name: "some-id",
+		address: "foo://bar",
+		source: "var foo = new Buffer();",
+		metadata: {}
+	})
+	.then(function(src){
+		var included = /require/.test(src);
+		assert.ok(!included, "shim wasn't added as a dependency");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("Doesn't add buffer when insertNodeGlobals meta is false", function(assert){
+	var done = assert.async();
+	var loader = helpers.clone().loader;
+
+	loader.translate({
+		name: "some-id",
+		address: "foo://bar",
+		source: "var foo = new Buffer();",
+		metadata: {
+			insertNodeGlobals: false
+		}
+	})
+	.then(function(src){
+		var included = /require/.test(src);
+		assert.ok(!included, "shim wasn't added as a dependency");
+	})
+	.then(done, helpers.fail(assert, done));
+});


### PR DESCRIPTION
This conditionally adds a dependency on the Node global `Buffer`. It
detects the new of the constructor (attempting to remove non-global
		usage) and if so, adds the shim as a dependency.

You can disable this behavior by setting `insertNodeGlobals: false`
either to be configured globally or in system.meta for a specific
module.