### PR TITLE
Always convert System.main into an npm module name

### DIFF
--- a/npm-load.js
+++ b/npm-load.js
@@ -77,14 +77,12 @@ exports.configDeps = function(context, pkg){
  */
 exports.pkgMain = function(context, pkg){
 	var pkgMain = utils.pkg.main(pkg);
-	// Convert the main if using directories.lib
-	if(utils.pkg.hasDirectoriesLib(pkg)) {
-		var mainHasPkg = pkgMain.indexOf(pkg.name) === 0;
-		if(mainHasPkg) {
-			pkgMain = convert.name(context, pkg, false, true, pkgMain);
-		} else {
-			pkgMain = convert.name(context, pkg, false, true, pkg.name+"/"+pkgMain);
-		}
+	// Convert the main
+	var mainHasPkg = pkgMain.indexOf(pkg.name) === 0;
+	if(mainHasPkg) {
+		pkgMain = convert.name(context, pkg, false, true, pkgMain);
+	} else {
+		pkgMain = convert.name(context, pkg, false, true, pkg.name+"/"+pkgMain);
 	}
 	return pkgMain;
 };

--- a/test/ext_config/package.json
+++ b/test/ext_config/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "extconfig",
 	"main": "main",
+	"version": "1.0.0",
 	"dependencies": {
 		"one": "1.0.0"
 	},

--- a/test/git_config/package.json
+++ b/test/git_config/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "mod",
 	"main": "main",
+	"version": "1.0.0",
 	"dependencies": {
 		"dep": "git://github.com/fake/thing#master"
 	},

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -54,7 +54,7 @@ QUnit.test("Allows a relative main", function(assert){
 			main: "./relative.js",
 			version: "1.0.0"
 		})
-		.withModule("relative", "module.exports = 'worked'")
+		.withModule("app@1.0.0#relative", "module.exports = 'worked'")
 		.loader;
 	
 	loader["import"]("package.json!npm")
@@ -186,7 +186,7 @@ QUnit.test("A project within a node_modules folder", function(assert){
 		.withConfig({
 			baseURL: "http://example.com/node_modules/project/something/else/"
 		})
-		.withModule("main", main)
+		.withModule("app@1.0.0#main", main)
 		.withModule("dep@1.0.0#main", dep)
 		.loader;
 

--- a/test/live-reload/dev.html
+++ b/test/live-reload/dev.html
@@ -42,7 +42,7 @@
 
 					doInstall().then(doChangeMain).then(function(){
 						// main should be right;
-						var main = System.get("main")["default"];
+						var main = System.get(System.main)["default"];
 						if(window.QUnit) {
 							QUnit.ok(main.fn.jquery, "jquery it is!");
 						} else {

--- a/test/load_test.js
+++ b/test/load_test.js
@@ -1,0 +1,45 @@
+var helpers = require("./helpers")(System);
+var utils = require("npm-utils");
+
+QUnit.module("package.json load object");
+
+QUnit.test("System.main contains the package name without directories.lib",
+		   function(assert){
+	var done = assert.async();
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js"
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		assert.equal(loader.main, "app@1.0.0#main", "correctly normalized");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("System.main contains the package name with directories.lib",
+		   function(assert){
+	var done = assert.async();
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			version: "1.0.0",
+			main: "main.js",
+			system: {
+				directories: {
+					lib: "src"
+				}
+			}
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		assert.equal(loader.main, "app@1.0.0#main", "correctly normalized");
+	})
+	.then(done, helpers.fail(assert, done));
+});

--- a/test/map_same/package.json
+++ b/test/map_same/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "mod",
 	"main": "main",
+	"version": "1.0.0",
 	"dependencies": {
 		"can": "1.0.0"
 	},

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ require("./utils_test");
 require("./crawl_test");
 require("./normalize_test");
 require("./import_test");
+require("./load_test");
 
 var makeIframe = function(src){
 	var iframe = document.createElement('iframe');


### PR DESCRIPTION
This makes it so that System.main is always in the form of
`package@version#path`, fixing potential bugs if someone were to mix
using `package/` when their System.main is not an NPM moduleName.

Related to https://github.com/stealjs/steal/issues/754