### PR TITLE
Correctly normalize ..

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -66,24 +66,6 @@ exports.addExtension = function(System){
 									 pluginNormalize);
 		}
 
-		// If name is ./ or ../
-		var isPointingAtParentFolder = name === "../" || name === "./";
-
-		if(parentIsNpmModule && isPointingAtParentFolder) {
-			var parsedParentModuleName = utils.moduleName.parse(parentName);
-			var parentModulePath = parsedParentModuleName.modulePath || "";
-			var relativePath = utils.path.relativeTo(parentModulePath, name);
-			var isInRoot = utils.path.isPackageRootDir(relativePath);
-
-			if(isInRoot) {
-				name = refPkg.name + "#" + utils.path.removeJS(refPkg.main);
-
-			} else {
-				name = name + "index";
-			}
-		}
-
-
 		// Using the current package, get info about what it is probably asking for
 		var parsedModuleName = utils.moduleName.parseFromPackage(this, refPkg,
 																 name,

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -219,12 +219,33 @@ var utils = {
 			// If the module needs to be loaded relative.
 			if(isRelative) {
 				// get the location of the parent
-				var parentParsed = utils.moduleName.parse( parentName, packageName );
+				var parentParsed = utils.moduleName.parse(parentName, packageName);
+
 				// If the parentModule and the currentModule are from the same parent
 				if( parentParsed.packageName === parsedModuleName.packageName && parentParsed.modulePath ) {
-					// Make the path relative to the parentName's path.
-					parsedModuleName.modulePath = utils.path.makeRelative(
-						utils.path.joinURIs(parentParsed.modulePath, parsedModuleName.modulePath) );
+					var makePathRelative = true;
+
+					if(name === "../" || name === "./" || name === "..") {
+						var relativePath = utils.path.relativeTo(
+							parentParsed.modulePath, name);
+						var isInRoot = utils.path.isPackageRootDir(relativePath);
+						if(isInRoot) {
+							parsedModuleName.modulePath = utils.pkg.main(refPkg);
+							makePathRelative = false;
+						} else {
+							parsedModuleName.modulePath = name + 
+								(utils.path.endsWithSlash(name) ? "" : "/") +
+								"index";
+						}
+					} 
+					
+					if(makePathRelative) {
+						// Make the path relative to the parentName's path.
+						parsedModuleName.modulePath = utils.path.makeRelative(
+							utils.path.joinURIs(parentParsed.modulePath,
+												parsedModuleName.modulePath)
+						);
+					}
 				}
 			}
 

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -237,8 +237,20 @@ QUnit.test("Loads npm convention of folder with trailing slash", function(assert
 		// Relative to the parent folder uses index
 		assert.equal(name, "dep@1.0.0#folder/index");
 
+		return loader.normalize("..", "dep@1.0.0#folder/deep/mod");
+	})
+	.then(function(name){
+		// Relative to the parent folder uses index
+		assert.equal(name, "dep@1.0.0#folder/index");
+
 		// Loading to the parent-most folder of the package
 		return loader.normalize("../", "dep@1.0.0#folder/mod");
+	})
+	.then(function(name){
+		// Relative to parent-most is the pkg.main
+		assert.equal(name, "dep@1.0.0#main");
+
+		return loader.normalize("..", "dep@1.0.0#folder/mod");
 	})
 	.then(function(name){
 		// Relative to parent-most is the pkg.main


### PR DESCRIPTION
This updates utils.moduleName.parseFromPackage to correctly parse
a name ".." that is coming from a parent package. We already had logic
for ../ and ./, so just needed to adjust it to work with ..

Additionally moved this logic into utils.moduleName.parseFromPackage
where it belongs, rather than directly in the normalize hook.

For https://github.com/stealjs/steal/issues/770