### PR TITLE
Correctly handle directories.lib variations

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -311,7 +311,7 @@ var utils = {
 				utils.path.removePackage( pkg.fileUrl ) :
 				utils.path.pkgDir(pkg.fileUrl);
 
-			var lib = pkg.system && pkg.system.directories && pkg.system.directories.lib;
+			var lib = utils.pkg.directoriesLib(pkg);
 			if(lib) {
 				root = utils.path.joinURIs(utils.path.addEndingSlash(root), lib);
 			}
@@ -416,6 +416,20 @@ var utils = {
 				url = utils.pkg.folderAddress(url);
 				return loader.npmPaths[url];
 			}
+		},
+		directoriesLib: function(pkg) {
+			var system = pkg.system;
+			var lib = system && system.directories && system.directories.lib;
+			var ignores = [".", "/"], ignore;
+			
+			if(!lib) return undefined;
+
+			while(!!(ignore = ignores.shift())) {
+				if(lib[0] === ignore) {
+					lib = lib.substr(1);
+				}
+			}
+			return lib;
 		},
 		hasDirectoriesLib: function(pkg) {
 			var system = pkg.system;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "can": "2.3.9",
     "copy-dir": "0.0.8",
     "jquery": "2.1.3",
-    "jquery-ui": "^1.10.5",
+    "jquery-ui": "1.10.5",
     "live-reload-testing": "^4.0.0",
     "lodash": "~2.4.1",
     "qunit": "~0.7.5",

--- a/test/locate_test.js
+++ b/test/locate_test.js
@@ -1,0 +1,33 @@
+var helpers = require("./helpers")(System);
+
+QUnit.module("locating");
+
+QUnit.test("directories.lib: '.' works", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			system: {
+				directories: {
+					lib: "."
+				}
+			}
+		})
+		.withConfig({
+			baseURL: "/foo/bar"
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.locate({ name: "app@1.0.0#main", metadata: {} });
+	})
+	.then(function(address){
+		console.log(address);
+		assert.ok(/foo\/bar\//.test(address), "inside the baseURL");
+	})
+	.then(done, helpers.fail(assert, done));
+});

--- a/test/locate_test.js
+++ b/test/locate_test.js
@@ -26,8 +26,94 @@ QUnit.test("directories.lib: '.' works", function(assert){
 		return loader.locate({ name: "app@1.0.0#main", metadata: {} });
 	})
 	.then(function(address){
-		console.log(address);
 		assert.ok(/foo\/bar\//.test(address), "inside the baseURL");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("directories.lib: './' works", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			system: {
+				directories: {
+					lib: "./"
+				}
+			}
+		})
+		.withConfig({
+			baseURL: "/foo/bar"
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.locate({ name: "app@1.0.0#main", metadata: {} });
+	})
+	.then(function(address){
+		assert.ok(/foo\/bar\//.test(address), "inside the baseURL");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("directories.lib: './something' works", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			system: {
+				directories: {
+					lib: "./something"
+				}
+			}
+		})
+		.withConfig({
+			baseURL: "/foo/bar"
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.locate({ name: "app@1.0.0#main", metadata: {} });
+	})
+	.then(function(address){
+		assert.ok(/foo\/bar\/something\//.test(address), "inside the baseURL");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("directories.lib: bare value works", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			system: {
+				directories: {
+					lib: "something"
+				}
+			}
+		})
+		.withConfig({
+			baseURL: "/foo/bar"
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.locate({ name: "app@1.0.0#main", metadata: {} });
+	})
+	.then(function(address){
+		assert.ok(/foo\/bar\/something\//.test(address), "inside the baseURL");
 	})
 	.then(done, helpers.fail(assert, done));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ require("./utils_test");
 require("./crawl_test");
 require("./normalize_test");
 require("./import_test");
+require("./locate_test");
 
 var makeIframe = function(src){
 	var iframe = document.createElement('iframe');


### PR DESCRIPTION
This makes it so we correctly handle directories.lib variations where
the "." is included such as:

* "."
* "./"
* "./something"

And also adds a test for a bare value (what we most common use) like:

* "src"

Fixes #166