### PR TITLE
Restore system.main after applying config

### DIFF
--- a/npm-convert.js
+++ b/npm-convert.js
@@ -68,9 +68,12 @@ function convertSystem(context, pkg, system, root, ignoreWaiting) {
 				info.system = config;
 			}
 
+			// Temporarily remove system.main so that it doesn't set System.main
+			var systemMain = config.main;
 			delete config.main;
 			delete config.transpiler;
 			context.loader.config(config);
+			config.main = systemMain;
 		});
 	}
 

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -43,7 +43,7 @@ var utils = {
 		for(; i < len; i++) {
 			res = fn.call(arr, arr[i]);
 			if(res) {
-				out.push(res);
+				out.push(arr[i]);
 			}
 		}
 		return out;

--- a/test/steal.html
+++ b/test/steal.html
@@ -17,6 +17,7 @@
 		steal = {
 			paths: {
 				"npm": "npm.js",
+				"npm-convert": "npm-convert.js",
 				"npm-extension": "npm-extension.js",
 				"npm-crawl": "npm-crawl.js",
 				"npm-utils": "npm-utils.js"


### PR DESCRIPTION
A couple of places we need to run a package.json' `system` property
through `loader.config()` in order to configure the loader. Whenever we
do this we remove the `system.main` property so that `System.main` is
not set (this will be the app's "main"). In one place we forgot to
restore this property afterwards, as it's needed to properly normalize
in production.

Fixes #168