### PR TITLE
Save dependency resolutions so that they can be compared in production.

### DIFF
--- a/npm-convert.js
+++ b/npm-convert.js
@@ -290,7 +290,8 @@ function convertToPackage(context, pkg, index) {
 			globalBrowser: convertBrowser(pkg, pkg.globalBrowser),
 			browser: convertBrowser(pkg, pkg.browser || pkg.browserify),
 			jspm: convertJspm(pkg, pkg.jspm),
-			jam: convertJspm(pkg, pkg.jam)
+			jam: convertJspm(pkg, pkg.jam),
+			resolutions: {}
 		};
 		packages.push(localPkg);
 		packages[nameAndVersion] = true;

--- a/npm-extension.js
+++ b/npm-extension.js
@@ -92,6 +92,7 @@ exports.addExtension = function(System){
 
 		var context = this.npmContext;
 		var crawl = context && context.crawl;
+		var isDev = !!crawl;
 		if(!depPkg) {
 			if(crawl && !isRoot) {
 				var parentPkg = nameIsRelative ? null :
@@ -109,9 +110,8 @@ exports.addExtension = function(System){
 					}
 				}
 			} else {
-
-			//if(!depPkg) {
-				depPkg = utils.pkg.findDep(this, refPkg, parsedModuleName.packageName);
+				depPkg = utils.pkg.findDep(this, refPkg,
+										   parsedModuleName.packageName);
 			}
 		}
 
@@ -128,10 +128,12 @@ exports.addExtension = function(System){
 			depPkg = utils.pkg.findByName(this, parsedModuleName.packageName);
 		}
 
-		var isThePackageWeWant = !crawl || !depPkg ||
+		var isThePackageWeWant = !isDev || !depPkg ||
 			(wantedPkg ? crawl.pkgSatisfies(depPkg, wantedPkg.version) : true);
 		if(!isThePackageWeWant) {
 			depPkg = undefined;
+		} else if(isDev && depPkg) {
+			utils.pkg.saveResolution(refPkg, depPkg);
 		}
 
 		// It could be something like `fs` so check in globals

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -374,30 +374,15 @@ var utils = {
 			}
 		},
 		/**
-		 * Walks up npmPaths looking for a [name]/package.json.  Returns
-		 * the package data it finds.
-		 *
-		 * @param {Loader} loader
-		 * @param {NpmPackage} refPackage
-		 * @param {packgeName} name the package name we are looking for.
-		 *
-		 * @return {undefined|NpmPackage}
+		 * Finds a dependency by its saved resolutions. This will only be called
+		 * after we've first successful found a package the "hard way" by doing
+		 * semver matching.
 		 */
-		findDep: function (loader, refPackage, name) {
-			if(loader.npm && refPackage && !utils.path.startsWithDotSlash(name)) {
-				// Todo .. first part of name
-				var curPackage = utils.path.depPackageDir(refPackage.fileUrl, name);
-				while(curPackage) {
-					var pkg = loader.npmPaths[curPackage];
-					if(pkg) {
-						return pkg;
-					}
-					var parentAddress = utils.path.parentNodeModuleAddress(curPackage);
-					if(!parentAddress) {
-						return;
-					}
-					curPackage = parentAddress+"/"+name;
-				}
+		findDep: function(loader, refPkg, name){
+			if(loader.npm && refPkg && !utils.path.startsWithDotSlash(name)) {
+				var nameAndVersion = name + "@" + refPkg.resolutions[name];
+				var pkg = loader.npm[nameAndVersion];
+				return pkg;
 			}
 		},
 		findByName: function(loader, name) {
@@ -446,6 +431,9 @@ var utils = {
 				});
 				return out;
 			}
+		},
+		saveResolution: function(refPkg, pkg){
+			refPkg.resolutions[pkg.name] = pkg.version;
 		}
 	},
 	path: {

--- a/npm.js
+++ b/npm.js
@@ -70,7 +70,8 @@ exports.translate = function(load){
 					globalBrowser: convert.browser(pkg, pkg.globalBrowser),
 					browser: convert.browser(pkg, pkg.browser || pkg.browserify),
 					jspm: convert.jspm(pkg, pkg.jspm),
-					jam: convert.jspm(pkg, pkg.jam)
+					jam: convert.jspm(pkg, pkg.jam),
+					resolutions: {}
 				});
 				packages[pkg.name+"@"+pkg.version] = true;
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -153,7 +153,8 @@ asyncTest("Support cloned loader", function(){
 		fileUrl: origDefault.fileUrl,
 		main: origDefault.main,
 		name: origDefault.name,
-		version: origDefault.version
+		version: origDefault.version,
+		resolutions: {}
 	};
 
 	GlobalSystem.normalize(origDefault.name)


### PR DESCRIPTION
Closes #170

Now when we find a dependency we save which version was used to resolve
it, so that info can be reused in prod.