### PR TITLE
Save resolutions on both npmPaths and pkgInfo in dev

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -110,8 +110,13 @@ exports.addExtension = function(System){
 					}
 				}
 			} else {
-				depPkg = utils.pkg.findDep(this, refPkg,
-										   parsedModuleName.packageName);
+				if(isRoot) {
+					depPkg = utils.pkg.findDepWalking(this, refPkg,
+													  parsedModuleName.packageName);
+				} else {
+					depPkg = utils.pkg.findDep(this, refPkg, 
+											   parsedModuleName.packageName);
+				}
 			}
 		}
 
@@ -133,7 +138,7 @@ exports.addExtension = function(System){
 		if(!isThePackageWeWant) {
 			depPkg = undefined;
 		} else if(isDev && depPkg) {
-			utils.pkg.saveResolution(refPkg, depPkg);
+			utils.pkg.saveResolution(context, refPkg, depPkg);
 		}
 
 		// It could be something like `fs` so check in globals

--- a/npm-utils.js
+++ b/npm-utils.js
@@ -385,6 +385,33 @@ var utils = {
 				return pkg;
 			}
 		},
+		/**
+		 * Walks up npmPaths looking for a [name]/package.json.  Returns
+		 * the package data it finds.
+		 *
+		 * @param {Loader} loader
+		 * @param {NpmPackage} refPackage
+		 * @param {packgeName} name the package name we are looking for.
+		 *
+		 * @return {undefined|NpmPackage}
+		 */
+		findDepWalking: function (loader, refPackage, name) {
+			if(loader.npm && refPackage && !utils.path.startsWithDotSlash(name)) {
+				// Todo .. first part of name
+				var curPackage = utils.path.depPackageDir(refPackage.fileUrl, name);
+				while(curPackage) {
+					var pkg = loader.npmPaths[curPackage];
+					if(pkg) {
+						return pkg;
+					}
+					var parentAddress = utils.path.parentNodeModuleAddress(curPackage);
+					if(!parentAddress) {
+						return;
+					}
+					curPackage = parentAddress+"/"+name;
+				}
+			}
+		},
 		findByName: function(loader, name) {
 			if(loader.npm && !utils.path.startsWithDotSlash(name)) {
 				return loader.npm[name];
@@ -432,8 +459,10 @@ var utils = {
 				return out;
 			}
 		},
-		saveResolution: function(refPkg, pkg){
-			refPkg.resolutions[pkg.name] = pkg.version;
+		saveResolution: function(context, refPkg, pkg){
+			var npmPkg = utils.pkg.findPackageInfo(context, refPkg);
+			npmPkg.resolutions[pkg.name] = refPkg.resolutions[pkg.name] =
+				pkg.version;
 		}
 	},
 	path: {

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -37,7 +37,7 @@ QUnit.test("normalizes child package names", function(assert){
 	.then(function(name){
 		assert.equal(name, "child@1.0.0#main", "Normalized to the parent");
 	})
-	.then(done, done);
+	.then(done, helpers.fail(assert, done));
 });
 
 QUnit.test("a package with .js in the name", function(assert){


### PR DESCRIPTION
This could be improved, I don't think both objects are needed any more,
	 we can probably dump npmPaths entirely and only use `loader.npm`
	 for lookup purposes. For now going to make it so both hold the
	 resolutions info.