### PR TITLE
process.platform is undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,49 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
 bower_components/
 node_modules/**
 test/live-reload/node_modules/

--- a/npm-load.js
+++ b/npm-load.js
@@ -113,7 +113,7 @@ var translateConfig = function(loader, packages, options){
 				NODE_ENV: loader.env
 			},
 			version: '',
-			platform: (navigator && navigator.userAgent && '/Windows/'.text(navigator.userAgent)) ? "win" : ""
+			platform: (navigator && navigator.userAgent && '/Windows/'.test(navigator.userAgent)) ? "win" : ""
 		};
 	}
 

--- a/npm-load.js
+++ b/npm-load.js
@@ -112,7 +112,8 @@ var translateConfig = function(loader, packages, options){
 			env: {
 				NODE_ENV: loader.env
 			},
-			version: ''
+			version: '',
+			platform: (navigator && navigator.userAgent && '/Windows/'.text(navigator.userAgent)) ? "win" : ""
 		};
 	}
 

--- a/npm-load.js
+++ b/npm-load.js
@@ -113,7 +113,7 @@ var translateConfig = function(loader, packages, options){
 				NODE_ENV: loader.env
 			},
 			version: '',
-			platform: (navigator && navigator.userAgent && '/Windows/'.test(navigator.userAgent)) ? "win" : ""
+			platform: (navigator && navigator.userAgent && /Windows/.test(navigator.userAgent)) ? "win" : ""
 		};
 	}
 


### PR DESCRIPTION
tqwhite have in some scenario problems with the system-js "isWindows" check.

http://forums.donejs.com/t/process-platform-match-is-not-a-function/364/7
i added a simple regex test if the useragent contain Windows otherwise process.platform is empty and did not throw an error on system-npm

@matthewp please have a short look.
btw. we should patch the minor release with the current patches of the master.