### PR TITLE
Save previous package information before creating initial source

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -77,9 +77,8 @@ exports.translate = function(load){
 			}
 		});
 
-		var source = npmLoad.makeSource(context, pkg);
-
 		npmLoad.addExistingPackages(context, prevPackages);
+		var source = npmLoad.makeSource(context, pkg);
 
 		return source;
 	});

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -68,6 +68,34 @@ QUnit.test("Allows a relative main", function(assert){
 	.then(done, done);
 });
 
+QUnit.test("Previous packages are included in the package.json!npm source",
+		   function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.loader;
+
+	loader.npmContext = {
+		pkgInfo: [
+			{ name: "some-pkg", main: "main.js", version: "1.0.0", fileUrl: "" }
+		]
+	};
+
+	helpers.init(loader)
+	.then(function(){
+		console.log("here");
+		var load = loader.getModuleLoad("package.json!npm");
+		var hasPkg = load.source.indexOf("some-pkg") !== -1;
+		assert.ok(hasPkg, "the previous packages were applied to the source");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 QUnit.test("A project within a node_modules folder", function(assert){
 	var done = assert.async();
 


### PR DESCRIPTION
Before creating the initial source for package.json!npm, first copy over
any configuration that comes from a previous graph analysis. This is
needed when loading multiple bundles during steal-tool's build.

Fixes #174