### PR TITLE
Save previous package information before creating initial source

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -85,9 +85,8 @@ exports.translate = function(load){
 			}
 		});
 
-		var source = npmLoad.makeSource(context, pkg);
-
 		npmLoad.addExistingPackages(context, prevPackages);
+		var source = npmLoad.makeSource(context, pkg);
 
 		return source;
 	});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "can": "2.3.9",
     "copy-dir": "0.0.8",
     "jquery": "2.1.3",
-    "jquery-ui": "^1.10.5",
+    "jquery-ui": "1.10.5",
     "live-reload-testing": "^4.0.0",
     "lodash": "~2.4.1",
     "qunit": "~0.7.5",

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -200,6 +200,34 @@ QUnit.test("A project within a node_modules folder", function(assert){
 	.then(done, helpers.fail(assert, done));
 });
 
+QUnit.test("Previous packages are included in the package.json!npm source",
+		   function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.loader;
+
+	loader.npmContext = {
+		pkgInfo: [
+			{ name: "some-pkg", main: "main.js", version: "1.0.0", fileUrl: "" }
+		]
+	};
+
+	helpers.init(loader)
+	.then(function(){
+		console.log("here");
+		var load = loader.getModuleLoad("package.json!npm");
+		var hasPkg = load.source.indexOf("some-pkg") !== -1;
+		assert.ok(hasPkg, "the previous packages were applied to the source");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 QUnit.module("Importing npm modules with tilde operator");
 
 QUnit.test("Import module with the ~ operator", function (assert) {


### PR DESCRIPTION
Before creating the initial source for package.json!npm, first copy over
any configuration that comes from a previous graph analysis. This is
needed when loading multiple bundles during steal-tool's build.

Fixes #174