### PR TITLE
Ignore global config when progressively loaded packages are loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ node_modules/**
 test/live-reload/node_modules/
 test/conditionals/node_modules/steal-conditional
 npm-debug.log
+.DS_Store

--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -285,12 +285,15 @@ var crawl = {
 			}
 			loader.npm[name+"@"+pkg.version] = pkg;
 		};
-
 		if(pkg.system) {
+			var ignoredConfig = ["bundle", "configDependencies", "transpiler"];
+
 			// don't set system.main
 			var main = pkg.system.main;
 			delete pkg.system.main;
-			delete pkg.system.configDependencies;
+			utils.forEach(ignoredConfig, function(name){
+				delete pkg.system[name];
+			});
 			loader.config(pkg.system);
 			pkg.system.main = main;
 


### PR DESCRIPTION
Unfortunately this code cannot be shared between progressively loaded
packages with the same code that exists in npm-load.js. This is because
the code in npm-load.js is inside of function that is toStringed and
that turns into the `package.json` JavaScript module. So that code must
be self-contained.