### PR TITLE
Move configuration to "steal" option

### DIFF
--- a/npm-convert.js
+++ b/npm-convert.js
@@ -3,7 +3,7 @@
 var crawl = require('./npm-crawl');
 var utils = require("./npm-utils");
 
-exports.system = convertSystem;
+exports.steal = convertSteal;
 exports.propertyNames = convertPropertyNames;
 exports.propertyNamesAndValues = convertPropertyNamesAndValues;
 exports.name = convertName;
@@ -34,24 +34,28 @@ exports.forPackage = convertForPackage;
 
 // Translate helpers ===============
 // Given all the package.json data, these helpers help convert it to a source.
-function convertSystem(context, pkg, system, root, ignoreWaiting) {
-	if(!system) {
-		return system;
+function convertSteal(context, pkg, steal, root, ignoreWaiting) {
+	if(!steal) {
+		return steal;
 	}
-	var copy = utils.extend({}, system, true);
+	var copy = utils.extend({}, steal, true);
 	var waiting = utils.isArray(ignoreWaiting) ? ignoreWaiting : [];
-	if(system.meta) {
-		system.meta = convertPropertyNames(context, pkg, system.meta, root, waiting);
+	if(steal.meta) {
+		steal.meta = convertPropertyNames(context, pkg, steal.meta, root,
+										  waiting);
 	}
-	if(system.map) {
-		system.map = convertPropertyNamesAndValues(context, pkg, system.map, root, waiting);
+	if(steal.map) {
+		steal.map = convertPropertyNamesAndValues(context, pkg, steal.map,
+												  root, waiting);
 	}
-	if(system.paths) {
-		system.paths = convertPropertyNames(context, pkg, system.paths, root, waiting);
+	if(steal.paths) {
+		steal.paths = convertPropertyNames(context, pkg, steal.paths, root,
+										   waiting);
 	}
 	// needed for builds
-	if(system.buildConfig) {
-		system.buildConfig = convertSystem(context, pkg, system.buildConfig, root, waiting);
+	if(steal.buildConfig) {
+		steal.buildConfig = convertSteal(context, pkg, steal.buildConfig,
+										  root, waiting);
 	}
 
 	// Push the waiting conversions down.
@@ -59,25 +63,25 @@ function convertSystem(context, pkg, system, root, ignoreWaiting) {
 		convertLater(context, waiting, function(){
 			var context = this;
 			var local = utils.extend({}, copy, true);
-			var config = convertSystem(context, pkg, local, root, true);
+			var config = convertSteal(context, pkg, local, root, true);
 
 			// If we are building we need to resave the package's system
 			// configuration so that it will be written out into the build.
 			if(context.resavePackageInfo) {
 				var info = utils.pkg.findPackageInfo(context, pkg);
-				info.system = config;
+				info.steal = info.system = config;
 			}
 
-			// Temporarily remove system.main so that it doesn't set System.main
-			var systemMain = config.main;
+			// Temporarily remove steal.main so that it doesn't set System.main
+			var stealMain = config.main;
 			delete config.main;
 			delete config.transpiler;
 			context.loader.config(config);
-			config.main = systemMain;
+			config.main = stealMain;
 		});
 	}
 
-	return system;
+	return steal;
 }
 
 // converts only the property name
@@ -289,6 +293,7 @@ function convertToPackage(context, pkg, index) {
 			name: pkg.fileUrl.split('/').pop(),
 			metadata: {}
 		}, pkg);
+		var steal = utils.pkg.config(pkg);
 
 		localPkg = {
 			name: pkg.name,
@@ -297,7 +302,7 @@ function convertToPackage(context, pkg, index) {
 				pkg.fileUrl :
 				utils.relativeURI(context.loader.baseURL, pkg.fileUrl),
 			main: pkg.main,
-			system: convertSystem(context, pkg, pkg.system, index === 0),
+			steal: convertSteal(context, pkg, steal, index === 0),
 			globalBrowser: convertBrowser(pkg, pkg.globalBrowser),
 			browser: convertBrowser(pkg, pkg.browser || pkg.browserify),
 			jspm: convertJspm(pkg, pkg.jspm),

--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -158,9 +158,11 @@ var crawl = {
 	 * @return {Object<String,Range>} A map of dependency names and requested version ranges.
 	 */
 	getDependencyMap: function(loader, packageJSON, isRoot){
-		var system = packageJSON.system;
+		var config = utils.pkg.config(packageJSON);
+		var hasConfig = !!config;
+
 		// convert npmIgnore
-		var npmIgnore = system && system.npmIgnore;
+		var npmIgnore = hasConfig && config.npmIgnore;
 		function convertToMap(arr) {
 			var npmMap = {};
 			for(var i = 0; i < arr.length; i++) {
@@ -169,12 +171,12 @@ var crawl = {
 			return npmMap;
 		}
 		if(npmIgnore && typeof npmIgnore.length === 'number') {
-			npmIgnore = packageJSON.system.npmIgnore = convertToMap(npmIgnore);
+			npmIgnore = config.npmIgnore = convertToMap(npmIgnore);
 		}
 		// convert npmDependencies
-		var npmDependencies = system && system.npmDependencies;
+		var npmDependencies = hasConfig && config.npmDependencies;
 		if(npmDependencies && typeof npmDependencies.length === "number") {
-			packageJSON.system.npmDependencies = convertToMap(npmDependencies);
+			config.npmDependencies = convertToMap(npmDependencies);
 		}
 		npmIgnore = npmIgnore || {};
 		
@@ -285,23 +287,24 @@ var crawl = {
 			}
 			loader.npm[name+"@"+pkg.version] = pkg;
 		};
-		if(pkg.system) {
+		var config = utils.pkg.config(pkg);
+		if(config) {
 			var ignoredConfig = ["bundle", "configDependencies", "transpiler"];
 
-			// don't set system.main
-			var main = pkg.system.main;
-			delete pkg.system.main;
+			// don't set steal.main
+			var main = config.main;
+			delete config.main;
 			utils.forEach(ignoredConfig, function(name){
-				delete pkg.system[name];
+				delete config[name];
 			});
-			loader.config(pkg.system);
-			pkg.system.main = main;
+			loader.config(config);
+			config.main = main;
 
 		}
 		if(pkg.globalBrowser) {
 			setGlobalBrowser(pkg.globalBrowser, pkg);
 		}
-		var systemName = pkg.system && pkg.system.name;
+		var systemName = config && config.name;
 		if(systemName) {
 			setInNpm(systemName, pkg);
 		} else {
@@ -343,9 +346,11 @@ function truthy(x) {
 var alwaysIgnore = {"steal-tools":1,"bower":1,"grunt":1,"grunt-cli":1};
 
 function addDeps(packageJSON, dependencies, deps, type, defaultProps){
+	var config = utils.pkg.config(packageJSON);
+
 	// convert an array to a map
-	var npmIgnore = packageJSON.system && packageJSON.system.npmIgnore;
-	var npmDependencies = packageJSON.system && packageJSON.system.npmDependencies;
+	var npmIgnore = config && config.npmIgnore;
+	var npmDependencies = config && config.npmDependencies;
 	var ignoreType = npmIgnore && npmIgnore[type];
 
 	function includeDep(name) {

--- a/npm-extension.js
+++ b/npm-extension.js
@@ -211,9 +211,10 @@ exports.addExtension = function(System){
 			}
 			var moduleName = utils.moduleName.create(parsedModuleName);
 			// Apply mappings, if they exist in the refPkg
-			if(refPkg.system && refPkg.system.map &&
-			   typeof refPkg.system.map[moduleName] === "string") {
-				moduleName = refPkg.system.map[moduleName];
+			var steal = utils.pkg.config(refPkg);
+			if(steal && steal.map &&
+			   typeof steal.map[moduleName] === "string") {
+				moduleName = steal.map[moduleName];
 			}
 			var p = oldNormalize.call(loader, moduleName, parentName,
 									  parentAddress, pluginNormalize);

--- a/npm.js
+++ b/npm.js
@@ -1,14 +1,11 @@
 "format cjs";
 
-// TODO: cleanup removing package.json
 var utils = require('./npm-utils');
 var convert = require("./npm-convert");
 var crawl = require('./npm-crawl');
 var npmLoad = require("./npm-load");
 var isNode = typeof process === "object" &&
 	{}.toString.call(process) === "[object process]";
-
-// SYSTEMJS PLUGIN EXPORTS =================
 
 /**
  * @function translate
@@ -50,11 +47,12 @@ exports.translate = function(load){
 	crawl.processPkgSource(context, pkg, load.source);
 
 	// backwards compatible for < npm 3
-	if(pkg.system && pkg.system.npmAlgorithm === "nested") {
+	var steal = utils.pkg.config(pkg);
+	if(steal && steal.npmAlgorithm === "nested") {
 		context.isFlatFileStructure = false;
 	} else {
-		pkg.system = pkg.system || {};
-		pkg.system.npmAlgorithm = "flat";
+		pkg.steal = steal = steal || {};
+		steal.npmAlgorithm = "flat";
 	}
 
 	return crawl.deps(context, pkg, true).then(function(){
@@ -67,6 +65,7 @@ exports.translate = function(load){
 					delete pkg.browser.transform;
 				}
 				pkg = utils.json.transform(loader, load, pkg);
+				var steal = utils.pkg.config(pkg);
 
 				packages.push({
 					name: pkg.name,
@@ -75,7 +74,7 @@ exports.translate = function(load){
 						pkg.fileUrl :
 						utils.relativeURI(context.loader.baseURL, pkg.fileUrl),
 					main: pkg.main,
-					system: convert.system(context, pkg, pkg.system, index === 0),
+					steal: convert.steal(context, pkg, steal, index === 0),
 					globalBrowser: convert.browser(pkg, pkg.globalBrowser),
 					browser: convert.browser(pkg, pkg.browser || pkg.browserify),
 					jspm: convert.jspm(pkg, pkg.jspm),

--- a/test/config_deps/dev.html
+++ b/test/config_deps/dev.html
@@ -25,7 +25,7 @@
 			if(hasQUnit()) {
 				QUnit.equal(window.DEP, "this is a config dep");
 				QUnit.notEqual(System.configDependencies[0], "my-dep", "An npm dependency's configDependencies should not be part of the configDependencies array.");
-				QUnit.ok(rootPkg.system.configDependencies, "there are config deps in the pkg");
+				QUnit.ok(rootPkg.steal.configDependencies, "there are config deps in the pkg");
 			} else {
 				console.log(window.DEP);
 			}

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -228,6 +228,51 @@ QUnit.test("Previous packages are included in the package.json!npm source",
 	.then(done, helpers.fail(assert, done));
 });
 
+QUnit.test("Configuration can be put on the 'steal' object in package.json",
+	function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			steal: {
+				foo: "bar"
+			}
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		assert.equal(loader.foo, "bar", "using steal as config works");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+QUnit.test("Configuration can be put on the 'system' object in package.json",
+	function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			system: {
+				foo: "bar"
+			}
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		assert.equal(loader.foo, "bar", "using steal as config works");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+
 QUnit.module("Importing npm modules with tilde operator");
 
 QUnit.test("Import module with the ~ operator", function (assert) {

--- a/test/json-options/build.js
+++ b/test/json-options/build.js
@@ -22,9 +22,9 @@ var promise = stealTools.build({
 			 * but we can filter out these configs, if necessary...
 			 */
 
-			if(json.system && json.system.ignoreBrowser === true){
+			if(json.steal && json.steal.ignoreBrowser === true){
 				delete json.browser;
-				delete json.system.ignoreBrowser;
+				delete json.steal.ignoreBrowser;
 			}
 
 			return json;

--- a/test/json-options/package.json
+++ b/test/json-options/package.json
@@ -9,7 +9,7 @@
 		"./util" : "./browser_util",
 		"transform": []
 	},
-	"system": {
+	"steal": {
 		"ignoreBrowser": true
 	},
 	"foo": "bar"

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -447,6 +447,11 @@ QUnit.test("normalizes in production when there is a dep in a parent node_module
 QUnit.module("normalizing with main config");
 
 var mainVariations = {
+	"steal.main": function(pkg){
+		pkg.steal = {
+			main: "bar"
+		};
+	},
 	"system.main": function(pkg){
 		pkg.system = {
 			main: "bar"
@@ -522,7 +527,7 @@ Object.keys(mainVariations).forEach(function(testName){
 	});
 });
 
-QUnit.test("A package's system.main is retained when loading dependant packages", function(assert){
+QUnit.test("A package's steal.main is retained when loading dependant packages", function(assert){
 	var done = assert.async();
 
 	var loader = helpers.clone()
@@ -566,7 +571,7 @@ QUnit.test("A package's system.main is retained when loading dependant packages"
 	.then(function(name){
 		var pkgs = loader.npmContext.pkgInfo;
 		var pkg = utils.filter(pkgs, function(p) { return p.name === "parent" })[0];
-		assert.equal(pkg.system.main, "other.js");
+		assert.equal(pkg.steal.main, "other.js");
 	})
 	.then(done, helpers.fail(assert, done));
 });


### PR DESCRIPTION
This moves configuration to a "steal" object in package.json and
deprecates the use of "system". "system" will still be allowed going
forward for backwards compatibility the same way "jam" and whatnot is.

Closes #164